### PR TITLE
Set a default value for `targetApplication`

### DIFF
--- a/helm_deploy/make-recall-decision-ui/values.yaml
+++ b/helm_deploy/make-recall-decision-ui/values.yaml
@@ -60,3 +60,6 @@ generic-service:
   #   cloudplatform-live1-1: "35.178.209.113/32"
   #   cloudplatform-live1-2: "3.8.51.207/32"
   #   cloudplatform-live1-3: "35.177.252.54/32"
+
+generic-prometheus-alerts:
+  targetApplication: make-recall-decision-ui


### PR DESCRIPTION
This is needed for the alerts templates - it's supplied in the env
specific configs, but for some reason we need a default.