### PR TITLE
MRD-28: Run the E2E tests "locally" on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       - run:
           name: Start components
           working_directory: make-recall-decision-ui
-          command: pwd && ./scripts/start-services-for-e2e-tests.sh
+          command: ./scripts/start-services-for-e2e-tests.sh
       - run:
           name: Run E2E tests
           working_directory: make-recall-decision-ui
@@ -255,7 +255,7 @@ workflows:
               only:
                 - main
 
-      - e2e_local_test
+      # - e2e_local_test
 
       - hmpps/deploy_env:
           name: deploy_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,12 @@ jobs:
       image: ubuntu-2004:202010-01
     parallelism: << pipeline.parameters.e2e-parallelism >>
     steps:
-      - checkout
+      - run:
+          name: Checkout/clone make-recall-decision-ui
+          command: |
+            git clone https://github.com/ministryofjustice/make-recall-decision-ui.git
+            cd make-recall-decision-ui
+            git checkout $CIRCLE_BRANCH
       - run:
           name: Checkout/clone make-recall-decision-api
           command: git clone https://github.com/ministryofjustice/make-recall-decision-api.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       - run:
           name: Start components
           working_directory: make-recall-decision-ui
-          command: ./scripts/start-services-for-e2e-tests.sh
+          command: pwd && ./scripts/start-services-for-e2e-tests.sh
       - run:
           name: Run E2E tests
           working_directory: make-recall-decision-ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ workflows:
       - integration_test:
           requires:
             - build
+      - e2e_local_test
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:
@@ -258,7 +259,6 @@ workflows:
               only:
                 - main
 
-      - e2e_local_test
 
       - hmpps/deploy_env:
           name: deploy_dev
@@ -272,6 +272,7 @@ workflows:
             - helm_lint
             - unit_test
             - integration_test
+            - e2e_local_test
             - build_docker
       - hmpps/sentry_release_and_deploy:
           name: notify_sentry_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,9 +191,7 @@ jobs:
       image: ubuntu-2004:202010-01
     parallelism: << pipeline.parameters.e2e-parallelism >>
     steps:
-      - run:
-          name: Checkout/clone make-recall-decision-ui
-          command: git clone https://github.com/ministryofjustice/make-recall-decision-ui.git
+      - checkout
       - run:
           name: Checkout/clone make-recall-decision-api
           command: git clone https://github.com/ministryofjustice/make-recall-decision-api.git
@@ -255,7 +253,7 @@ workflows:
               only:
                 - main
 
-      # - e2e_local_test
+      - e2e_local_test
 
       - hmpps/deploy_env:
           name: deploy_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ parameters:
   e2e-check-preprod:
     type: boolean
     default: false
+  e2e-parallelism:
+    type: integer
+    default: 1
 
 jobs:
   build:
@@ -140,7 +143,7 @@ jobs:
   e2e_environment_test:
     docker:
       - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
-    parallelism: 1
+    parallelism: << pipeline.parameters.e2e-parallelism >>
     parameters:
       environment:
         type: string
@@ -183,6 +186,83 @@ jobs:
       - store_test_results:
           path: e2e_tests/junit
 
+  e2e_local_test:
+    machine:
+      image: ubuntu-2004:202010-01
+    parallelism: << pipeline.parameters.e2e-parallelism >>
+    steps:
+      - run:
+          name: Checkout/clone make-recall-decision-ui
+          command: git clone https://github.com/ministryofjustice/make-recall-decision-ui.git
+      - run:
+          name: Checkout/clone make-recall-decision-api
+          command: git clone https://github.com/ministryofjustice/make-recall-decision-api.git
+      - run:
+          name: Start make-recall-decision-api components
+          working_directory: make-recall-decision-api
+          command: |
+            docker-compose pull
+            docker-compose build
+            docker-compose up -d
+      - run:
+          name: Start make-recall-decision-ui components
+          working_directory: make-recall-decision-ui
+          command: |
+            docker-compose pull
+            docker-compose build
+            docker-compose up -d --scale=hmpps-auth=0
+      - run:
+          name: Install E2E dependencies
+          working_directory: make-recall-decision-ui
+          command: npm ci --no-audit
+      - run:
+          name: Wait for services to be running
+          command: |
+            function wait_for {
+              printf "\n\nWaiting for ${2} to be ready.\n\n"
+              docker run --network host docker.io/jwilder/dockerize -wait ${1} -wait-retry-interval 2s -timeout 60s
+            }
+
+            wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"
+            wait_for "http://localhost:3000/ping" "make-recall-decision-ui"
+            wait_for "http://localhost:8080/health/readiness" "make-recall-decision-api"
+      - run:
+          name: Run E2E tests
+          working_directory: make-recall-decision-ui
+          command: |
+            SPECS=$(circleci tests glob e2e_tests/integration/*.feature | circleci tests split --split-by=timings | tr "\n" "," | tr " " ",")
+            echo "Running feature spec(s): ${SPECS}"
+
+            npx cypress run \
+              --config-file e2e_tests/cypress.json \
+              --browser chrome \
+              --record false \
+              --spec $SPECS
+
+            npm run e2e:report
+            node scripts/fix-junit-reports.js
+      - run:
+          when: on_fail
+          name: make-recall-decision-api - docker logs
+          working_directory: make-recall-decision-api
+          command: docker-compose logs
+      - run:
+          when: on_fail
+          name: make-recall-decision-ui - docker logs
+          working_directory: make-recall-decision-ui
+          command: docker-compose logs
+      - store_artifacts:
+          path: make-recall-decision-ui/e2e_tests/screenshots
+          destination: screenshots
+      - store_artifacts:
+          path: make-recall-decision-ui/e2e_tests/reports
+          destination: reports
+      - store_artifacts:
+          path: make-recall-decision-ui/e2e_tests/junit
+          destination: junit
+      - store_test_results:
+          path: make-recall-decision-ui/e2e_tests/junit
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -210,6 +290,8 @@ workflows:
             branches:
               only:
                 - main
+
+      - e2e_local_test
 
       - hmpps/deploy_env:
           name: deploy_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,49 +198,13 @@ jobs:
           name: Checkout/clone make-recall-decision-api
           command: git clone https://github.com/ministryofjustice/make-recall-decision-api.git
       - run:
-          name: Start make-recall-decision-api components
-          working_directory: make-recall-decision-api
-          command: |
-            docker-compose pull
-            docker-compose build
-            docker-compose up -d
-      - run:
-          name: Start make-recall-decision-ui components
+          name: Start components
           working_directory: make-recall-decision-ui
-          command: |
-            docker-compose pull
-            docker-compose build
-            docker-compose up -d --scale=hmpps-auth=0
-      - run:
-          name: Install E2E dependencies
-          working_directory: make-recall-decision-ui
-          command: npm ci --no-audit
-      - run:
-          name: Wait for services to be running
-          command: |
-            function wait_for {
-              printf "\n\nWaiting for ${2} to be ready.\n\n"
-              docker run --network host docker.io/jwilder/dockerize -wait ${1} -wait-retry-interval 2s -timeout 60s
-            }
-
-            wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"
-            wait_for "http://localhost:3000/ping" "make-recall-decision-ui"
-            wait_for "http://localhost:8080/health/readiness" "make-recall-decision-api"
+          command: ./scripts/start-services-for-e2e-tests.sh
       - run:
           name: Run E2E tests
           working_directory: make-recall-decision-ui
-          command: |
-            SPECS=$(circleci tests glob e2e_tests/integration/*.feature | circleci tests split --split-by=timings | tr "\n" "," | tr " " ",")
-            echo "Running feature spec(s): ${SPECS}"
-
-            npx cypress run \
-              --config-file e2e_tests/cypress.json \
-              --browser chrome \
-              --record false \
-              --spec $SPECS
-
-            npm run e2e:report
-            node scripts/fix-junit-reports.js
+          command: ./scripts/run-e2e-tests-on-ci.sh
       - run:
           when: on_fail
           name: make-recall-decision-api - docker logs

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ integration_tests/screenshots/
 e2e_tests/cucumber-json
 e2e_tests/junit
 e2e_tests/screenshots
+e2e_tests/reports

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,23 @@ services:
     image: 'bitnami/redis:5.0'
     networks:
       - hmpps
-    container_name: redis 
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
+    container_name: redis
     ports:
       - '6379:6379'
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
 
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
     networks:
       - hmpps
-    container_name: hmpps-auth 
+    container_name: hmpps-auth
     ports:
       - "9090:8080"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/ping"]
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
@@ -28,15 +30,18 @@ services:
     build: .
     networks:
       - hmpps
-    depends_on: [redis]
+    depends_on:
+      - redis
     ports:
       - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
     environment:
       - REDIS_HOST=redis
       - INGRESS_URL=http://localhost:3000
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
-      - MAKE_RECALL_DECISION_API_URL=http://localhost:9091
+      - MAKE_RECALL_DECISION_API_URL=http://make-recall-decision-api:8080
       - TOKEN_VERIFICATION_API_URL=http://localhost:9090/verification
       # These will need to match new creds in the seed auth service auth
       - API_CLIENT_ID=make-recall-decision-ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.9'
 services:
 
   redis:
@@ -26,8 +26,9 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
-  app:
-    build: .
+  make-recall-decision-ui:
+    build:
+      context: .
     networks:
       - hmpps
     depends_on:
@@ -37,12 +38,14 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
     environment:
+      - DEBUG=*
+      - NODE_ENV=development
       - REDIS_HOST=redis
       - INGRESS_URL=http://localhost:3000
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
       - MAKE_RECALL_DECISION_API_URL=http://make-recall-decision-api:8080
-      - TOKEN_VERIFICATION_API_URL=http://localhost:9090/verification
+      - TOKEN_VERIFICATION_API_URL=http://hmpps-auth:9090/verification
       # These will need to match new creds in the seed auth service auth
       - API_CLIENT_ID=make-recall-decision-ui
       - API_CLIENT_SECRET=clientsecret
@@ -52,3 +55,4 @@ services:
 
 networks:
   hmpps:
+    name: hmpps

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "int-test": "cypress run --config-file integration_tests/cypress.json",
     "int-test-ui": "cypress open --config-file integration_tests/cypress.json",
     "e2e": "npx cypress open --config-file e2e_tests/cypress.json",
-    "e2e:ci": "npx cypress run --browser edge --config-file e2e_tests/cypress.json",
+    "e2e:ci": "npx cypress run --browser chrome --config-file e2e_tests/cypress.json",
     "e2e:report": "node e2e_tests/cucumber-report.js",
     "clean": "rm -rf dist build node_modules stylesheets"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "int-test": "cypress run --config-file integration_tests/cypress.json",
     "int-test-ui": "cypress open --config-file integration_tests/cypress.json",
     "e2e": "npx cypress open --config-file e2e_tests/cypress.json",
-    "e2e:ci": "npx cypress run --browser chrome --config-file e2e_tests/cypress.json",
+    "e2e:ci": "npx cypress run --browser edge --config-file e2e_tests/cypress.json",
     "e2e:report": "node e2e_tests/cucumber-report.js",
     "clean": "rm -rf dist build node_modules stylesheets"
   },

--- a/scripts/run-e2e-tests-on-ci.sh
+++ b/scripts/run-e2e-tests-on-ci.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# npm ci --no-audit
+
+# SPECS=$(circleci tests glob e2e_tests/integration/*.feature | circleci tests split --split-by=timings | tr "\n" "," | tr " " ",")
+# echo "Running feature spec(s): ${SPECS}"
+
+npx cypress run \
+  --config-file e2e_tests/cypress.json \
+  --browser chrome \
+  --record false
+# --spec $SPECS
+
+npm run e2e:report
+node scripts/fix-junit-reports.js

--- a/scripts/run-e2e-tests-on-ci.sh
+++ b/scripts/run-e2e-tests-on-ci.sh
@@ -2,16 +2,16 @@
 
 set -euo pipefail
 
-# npm ci --no-audit
+npm ci --no-audit
 
-# SPECS=$(circleci tests glob e2e_tests/integration/*.feature | circleci tests split --split-by=timings | tr "\n" "," | tr " " ",")
-# echo "Running feature spec(s): ${SPECS}"
+SPECS=$(circleci tests glob e2e_tests/integration/*.feature | circleci tests split --split-by=timings | tr "\n" "," | tr " " ",")
+echo "Running feature spec(s): ${SPECS}"
 
 npx cypress run \
   --config-file e2e_tests/cypress.json \
   --browser chrome \
-  --record false
-# --spec $SPECS
+  --record false \
+  --spec $SPECS
 
 npm run e2e:report
 node scripts/fix-junit-reports.js

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -23,6 +23,8 @@ docker-compose build
 docker-compose up -d
 popd
 
+set +x
+
 function wait_for {
   printf "\n\nWaiting for %s to be ready.\n\n" "${2}"
   local TRIES=0
@@ -30,7 +32,7 @@ function wait_for {
     printf "."
     ((TRIES++))
 
-    if [ $TRIES -gt 50 ]; then
+    if [ "${TRIES}" -gt 50 ]; then
       printf "Failed to start %s after 50 tries." "${2}"
       exit 1
     fi

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -23,7 +23,7 @@ docker-compose build
 docker-compose up -d
 popd
 
-set +x
+set -x
 
 function wait_for {
   printf "\n\nWaiting for %s to be ready.\n\n" "${2}"

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -23,22 +23,9 @@ docker-compose build
 docker-compose up -d
 popd
 
-set -x
-
 function wait_for {
   printf "\n\nWaiting for %s to be ready.\n\n" "${2}"
-  local TRIES=0
-  until curl -s --fail "${1}"; do
-    printf "."
-    ((TRIES++))
-
-    if [ "${TRIES}" -gt 50 ]; then
-      printf "Failed to start %s after 50 tries." "${2}"
-      exit 1
-    fi
-
-    sleep 2
-  done
+  docker run --rm --network host docker.io/jwilder/dockerize -wait "${1}" -wait-retry-interval 2s -timeout 60s
 }
 
 wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -20,7 +20,7 @@ pushd "${UI_DIR}"
 printf "\n\nBuilding/starting UI components...\n\n"
 docker compose pull
 docker compose build
-docker compose up -d --scale=hmpps-auth=0
+docker compose up -d
 popd
 
 function wait_for {

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -12,14 +12,14 @@ readonly API_DIR="${SCRIPT_DIR}/../../${API_NAME}"
 pushd "${API_DIR}"
 printf "\n\nBuilding/starting API components...\n\n"
 docker-compose pull
-# docker-compose build
+docker-compose build
 docker-compose up -d
 popd
 
 pushd "${UI_DIR}"
 printf "\n\nBuilding/starting UI components...\n\n"
 docker compose pull
-# docker compose build
+docker compose build
 docker compose up -d --scale=hmpps-auth=0
 popd
 

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+readonly UI_NAME=make-recall-decision-ui
+readonly API_NAME=make-recall-decision-api
+readonly UI_DIR="${SCRIPT_DIR}/../../${UI_NAME}"
+readonly API_DIR="${SCRIPT_DIR}/../../${API_NAME}"
+
+pushd "${API_DIR}"
+printf "\n\nBuilding/starting API components...\n\n"
+docker-compose pull
+# docker-compose build
+docker-compose up -d
+popd
+
+pushd "${UI_DIR}"
+printf "\n\nBuilding/starting UI components...\n\n"
+docker compose pull
+# docker compose build
+docker compose up -d --scale=hmpps-auth=0
+popd
+
+function wait_for {
+  printf "\n\nWaiting for %s to be ready.\n\n" "${2}"
+  local TRIES=0
+  until curl -s --fail "${1}"; do
+    printf "."
+    ((TRIES++))
+
+    if [ $TRIES -gt 50 ]; then
+      printf "Failed to start %s after 50 tries." "${2}"
+      exit 1
+    fi
+
+    sleep 2
+  done
+}
+
+wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"
+wait_for "http://localhost:3000/ping" "make-recall-decision-ui"
+wait_for "http://localhost:8080/health/readiness" "make-recall-decision-api"
+
+printf "\n\nAll services are ready.\n\n"

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -18,9 +18,9 @@ popd
 
 pushd "${UI_DIR}"
 printf "\n\nBuilding/starting UI components...\n\n"
-docker compose pull
-docker compose build
-docker compose up -d
+docker-compose pull
+docker-compose build
+docker-compose up -d
 popd
 
 function wait_for {

--- a/scripts/stop-services-for-e2e-tests.sh
+++ b/scripts/stop-services-for-e2e-tests.sh
@@ -16,7 +16,7 @@ popd
 
 pushd "${UI_DIR}"
 printf "\n\nStopping UI components...\n\n"
-docker compose down
+docker-compose down
 popd
 
 printf "\n\nAll services are stopped.\n\n"

--- a/scripts/stop-services-for-e2e-tests.sh
+++ b/scripts/stop-services-for-e2e-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+readonly UI_NAME=make-recall-decision-ui
+readonly API_NAME=make-recall-decision-api
+readonly UI_DIR="${SCRIPT_DIR}/../../${UI_NAME}"
+readonly API_DIR="${SCRIPT_DIR}/../../${API_NAME}"
+
+pushd "${API_DIR}"
+printf "\n\nStopping API components...\n\n"
+docker-compose down
+popd
+
+pushd "${UI_DIR}"
+printf "\n\nStopping UI components...\n\n"
+docker compose down
+popd
+
+printf "\n\nAll services are stopped.\n\n"

--- a/scripts/stop-services-for-e2e-tests.sh
+++ b/scripts/stop-services-for-e2e-tests.sh
@@ -11,7 +11,7 @@ readonly API_DIR="${SCRIPT_DIR}/../../${API_NAME}"
 
 pushd "${API_DIR}"
 printf "\n\nStopping API components...\n\n"
-docker-compose down
+docker-compose down || true # ignore the network error, this will be cleared up by the next step
 popd
 
 pushd "${UI_DIR}"


### PR DESCRIPTION
The way this works is pulling down both UI and API, spinning up the `docker-compose` stack in both repos (connected on the same virtual network), then running the E2E's over those services.

The downside to this is that it takes ~3 minutes to build and spin up the stack, then however long the E2E's take... Not a lot we can do about that though I'm afraid. 😞 