### PR TITLE
MRD-107: Make the start scripts work for M1 macs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
       - run:
           name: Start components
           working_directory: make-recall-decision-ui
-          command: ./scripts/start-services-for-e2e-tests.sh
+          command: ./scripts/start-services-for-e2e-tests.sh -p
       - run:
           name: Run E2E tests
           working_directory: make-recall-decision-ui

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The app requires:
 - make-recall-decision-api - main API for the app
 
 ## Setup
+
 Install dependencies using `npm install`, ensuring you are using >= `Node v16.x`
 
 Copy the .env.sample file in the root of this repo and name the copy as .env, then complete with the missing env values (the team will provide them).
@@ -32,7 +33,18 @@ And then, to start the app:
 npm run start:dev
 ```
 
+### Notes for M1 Mac Users
+
+If you're using an M1/arm based Mac, you'll need to also have a checkout of [hmpps-auth](https://github.com/ministryofjustice/hmpps-auth) alongside your checkouts of `make-recall-decision-ui` and `make-recall-decision-api`, and pass all of the start scripts the `-a` parameter:
+
+```
+./scripts/start-services-no-ui.sh -a
+```
+
+This will build the `hmpps-auth` container image locally on your machine before starting things up. This is needed as the currently released container for `hmpps-auth` does not run properly on M1 macs.
+
 ## Automated tests and linting
+
 [Doc](./docs/lint-tests.md)
 
 ## E2E Tests on CircleCI

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -2,23 +2,71 @@
 
 set -euo pipefail
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_HMPPS_AUTH=false
+RUN_DOCKER_COMPOSE_PULL=false
 
+instructions() {
+  echo "Usage: $0 <opts>" >&2
+  echo " -h --> show usage" >&2
+  echo " -a --> build hmpps-auth - needed for M1 macs (default=${BUILD_HMPPS_AUTH})" >&2
+  echo " -p --> run docker-compose pull (default=${RUN_DOCKER_COMPOSE_PULL})" >&2
+}
+
+while getopts ":h:ap" option; do
+  case "${option}" in
+  h)
+    instructions
+    exit 0
+    ;;
+  a)
+    BUILD_HMPPS_AUTH=true
+    ;;
+  p)
+    RUN_DOCKER_COMPOSE_PULL=true
+    ;;
+  \?)
+    echo "Option '-$OPTARG' is not a valid option." >&2
+    instructions
+    exit 1
+    ;;
+  :)
+    echo "Option '-$OPTARG' needs an argument." >&2
+    instructions
+    exit 1
+    ;;
+  esac
+done
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly AUTH_NAME=hmpps-auth
 readonly UI_NAME=make-recall-decision-ui
 readonly API_NAME=make-recall-decision-api
+readonly AUTH_DIR="${SCRIPT_DIR}/../../${AUTH_NAME}"
 readonly UI_DIR="${SCRIPT_DIR}/../../${UI_NAME}"
 readonly API_DIR="${SCRIPT_DIR}/../../${API_NAME}"
 
+if [[ "${RUN_DOCKER_COMPOSE_PULL}" == "true" ]]; then
+  printf "\n\nRunning 'docker compose pull' on all services...\n\n"
+  docker-compose -f "${UI_DIR}/docker-compose.yml" pull
+  docker-compose -f "${API_DIR}/docker-compose.yml" pull
+fi
+
+if [[ "${BUILD_HMPPS_AUTH}" == "true" ]]; then
+  printf "\n\nBuilding hmpps-auth\n\n"
+  pushd "${AUTH_DIR}"
+  git pull origin main
+  docker build . --tag quay.io/hmpps/hmpps-auth:latest
+  popd
+fi
+
 pushd "${API_DIR}"
 printf "\n\nBuilding/starting API components...\n\n"
-docker-compose pull
 docker-compose build
 docker-compose up -d
 popd
 
 pushd "${UI_DIR}"
 printf "\n\nBuilding/starting UI components...\n\n"
-docker-compose pull
 docker-compose build
 docker-compose up -d
 popd
@@ -28,7 +76,7 @@ function wait_for {
   docker run --rm --network host docker.io/jwilder/dockerize -wait "${1}" -wait-retry-interval 2s -timeout 60s
 }
 
-wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"
+wait_for "http://localhost:9090/auth/health/ping" "${AUTH_NAME}"
 wait_for "http://localhost:3000/ping" "${UI_NAME}"
 wait_for "http://localhost:8081/health/readiness" "${API_NAME}"
 

--- a/scripts/stop-services-for-e2e-tests.sh
+++ b/scripts/stop-services-for-e2e-tests.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 readonly UI_NAME=make-recall-decision-ui
 readonly API_NAME=make-recall-decision-api
 readonly UI_DIR="${SCRIPT_DIR}/../../${UI_NAME}"


### PR DESCRIPTION
This adds options to control when to...

- Run `docker-compose pull` (this isn't needed all the time)
- Build `hmpps-auth` (only on M1 macs)

The `hmpps-auth` build step is needed at least once if you're running an M1 mac as the currently distributed container isn't multi arch and has running problems on M1 silicon.