### PR TITLE
Make the environment e2e use a restricted set of IPs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ jobs:
           path: integration_tests/screenshots
 
   e2e_environment_test:
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     docker:
       - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
     parallelism: << pipeline.parameters.e2e-parallelism >>


### PR DESCRIPTION
This should ensure they get through the IP allow list on the ingress