### PR TITLE
MRD-148 - Utility functions for date filters feature

### DIFF
--- a/server/@types/dates.d.ts
+++ b/server/@types/dates.d.ts
@@ -1,0 +1,36 @@
+export interface DatePartsParsed {
+  year: string
+  month: string
+  day: string
+  hour?: string
+  minute?: string
+}
+
+export type ValidationErrorType =
+  | 'dateMustBeInPast'
+  | 'dateMustBeInFuture'
+  | 'blankDateTime'
+  | 'invalidDate'
+  | 'missingDate'
+  | 'invalidTime'
+  | 'missingTime'
+  | 'missingDateParts'
+  | 'minLengthDateParts'
+  | 'minValueDateYear'
+  | 'minLengthDateTimeParts'
+  | 'minValueDateTimeParts'
+  | 'noSelectionFromList'
+  | 'invalidSelectionFromList'
+  | 'fromDateAfterToDate'
+
+export type DatePartNames = 'year' | 'month' | 'day' | 'hour' | 'minute'
+
+export interface DateTimePart {
+  name: DatePartNames
+  value: string
+}
+
+export interface ValidationError {
+  errorId: ValidationErrorType
+  invalidParts?: DatePartNames[]
+}

--- a/server/controllers/caseSummary/utils/filterContactsByDateRange.test.ts
+++ b/server/controllers/caseSummary/utils/filterContactsByDateRange.test.ts
@@ -1,0 +1,186 @@
+import { ContactSummary } from '../../../@types/make-recall-decision-api/models/ContactSummary'
+import { filterContactsByDateRange } from './filterContactsByDateRange'
+
+describe('filterDates', () => {
+  it('leaves the list unaltered if no dates supplied', () => {
+    const contactList = [
+      {
+        contactStartDate: '2022-05-04T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-21T11:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ] as ContactSummary[]
+    const { errors, contacts } = filterContactsByDateRange({
+      contacts: contactList,
+      filters: {},
+    })
+    expect(errors).toBeUndefined()
+    expect(contacts).toEqual(contactList)
+  })
+
+  it('leaves the list unaltered and returns an error if from date not entered and to date is entered', () => {
+    const contactList = [
+      {
+        contactStartDate: '2022-05-04T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-21T11:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ] as ContactSummary[]
+    const { errors, contacts } = filterContactsByDateRange({
+      contacts: contactList,
+      filters: {
+        'dateTo-day': '21',
+        'dateTo-month': '04',
+        'dateTo-year': '2022',
+      },
+    })
+    expect(errors).toEqual([{ href: '#dateFrom-day', name: 'dateFrom', text: 'Enter the from date' }])
+    expect(contacts).toEqual(contactList)
+  })
+
+  it('leaves the list unaltered and returns an error if from date is entered and to date not entered', () => {
+    const contactList = [
+      {
+        contactStartDate: '2022-05-04T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-21T11:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ] as ContactSummary[]
+    const { errors, contacts } = filterContactsByDateRange({
+      contacts: contactList,
+      filters: {
+        'dateFrom-day': '21',
+        'dateFrom-month': '04',
+        'dateFrom-year': '2022',
+      },
+    })
+    expect(errors).toEqual([{ href: '#dateTo-day', name: 'dateTo', text: 'Enter the to date' }])
+    expect(contacts).toEqual(contactList)
+  })
+
+  it('leaves the list unaltered and returns an error if from date is after to date', () => {
+    const contactList = [
+      {
+        contactStartDate: '2022-05-04T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-21T11:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ] as ContactSummary[]
+    const { errors, contacts } = filterContactsByDateRange({
+      contacts: contactList,
+      filters: {
+        'dateFrom-day': '22',
+        'dateFrom-month': '04',
+        'dateFrom-year': '2022',
+        'dateTo-day': '21',
+        'dateTo-month': '04',
+        'dateTo-year': '2022',
+      },
+    })
+    expect(errors).toEqual([
+      { href: '#dateFrom-day', name: 'dateFrom', text: 'The from date must be before the to date' },
+    ])
+    expect(contacts).toEqual(contactList)
+  })
+
+  it('leaves the list unaltered and returns errors if from date and to date are invalid', () => {
+    const contactList = [
+      {
+        contactStartDate: '2022-05-04T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-21T11:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ] as ContactSummary[]
+    const { errors, contacts } = filterContactsByDateRange({
+      contacts: contactList,
+      filters: {
+        'dateFrom-day': '32',
+        'dateFrom-month': '04',
+        'dateFrom-year': '2022',
+        'dateTo-day': '21',
+        'dateTo-month': '13',
+        'dateTo-year': '2022',
+      },
+    })
+    expect(errors).toEqual([
+      { href: '#dateFrom-day', name: 'dateFrom', text: 'The from date must be a real date', values: undefined },
+      { href: '#dateTo-day', name: 'dateTo', text: 'The to date must be a real date', values: undefined },
+    ])
+    expect(contacts).toEqual(contactList)
+  })
+
+  it('filters contacts by the supplied from and to dates and returns a label', () => {
+    const contactList = [
+      {
+        contactStartDate: '2022-05-04T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-20T23:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ] as ContactSummary[]
+    const { errors, contacts, selectedLabel } = filterContactsByDateRange({
+      contacts: contactList,
+      filters: {
+        'dateFrom-day': '03',
+        'dateFrom-month': '04',
+        'dateFrom-year': '2021',
+        'dateTo-day': '21',
+        'dateTo-month': '04',
+        'dateTo-year': '2022',
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(contacts).toEqual([
+      {
+        contactStartDate: '2022-04-21T10:03:00Z',
+        descriptionType: 'Management Oversight - Recall',
+      },
+      {
+        contactStartDate: '2022-04-20T23:30:00Z', // corrected due to daylight savings, so becomes 21st April
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+    ])
+    expect(selectedLabel).toEqual('03-04-2021 to 21-04-2022')
+  })
+})

--- a/server/controllers/caseSummary/utils/filterContactsByDateRange.ts
+++ b/server/controllers/caseSummary/utils/filterContactsByDateRange.ts
@@ -1,0 +1,89 @@
+import { DateTime, Interval } from 'luxon'
+import { NamedFormError, ObjectMap } from '../../../@types'
+import { ValidationError } from '../../../@types/dates'
+import { convertGmtDatePartsToUtc, moveDateToEndOfDay } from '../../../utils/dates/convert'
+import { ContactSummary } from '../../../@types/make-recall-decision-api/models/ContactSummary'
+import { dateHasError } from '../../../utils/dates'
+import { formatValidationErrorMessage, makeErrorObject } from '../../../utils/errors'
+
+const parseDateParts = ({
+  fieldPrefix,
+  filters,
+}: {
+  fieldPrefix: string
+  filters: ObjectMap<string>
+}): string | ValidationError => {
+  const dateTimeParts = {
+    day: filters[`${fieldPrefix}-day`],
+    month: filters[`${fieldPrefix}-month`],
+    year: filters[`${fieldPrefix}-year`],
+  }
+  return convertGmtDatePartsToUtc(dateTimeParts, {
+    includeTime: false,
+    dateMustBeInPast: true,
+    validatePartLengths: false,
+  })
+}
+
+export const filterContactsByDateRange = ({
+  contacts,
+  filters,
+}: {
+  contacts: ContactSummary[]
+  filters: ObjectMap<string>
+}): { errors?: NamedFormError[]; contacts: ContactSummary[]; selectedLabel?: string } => {
+  const dateFromIso = parseDateParts({ fieldPrefix: 'dateFrom', filters })
+  const dateToIso = parseDateParts({ fieldPrefix: 'dateTo', filters })
+  const dateFromIsBlank = dateHasError(dateFromIso) && (dateFromIso as ValidationError).errorId === 'blankDateTime'
+  const dateToIsBlank = dateHasError(dateToIso) && (dateToIso as ValidationError).errorId === 'blankDateTime'
+
+  // if both dates are blank, don't show an error, just return the unfiltered contacts
+  if (dateFromIsBlank && dateToIsBlank) {
+    return { contacts }
+  }
+  // other errors
+  if (dateHasError(dateFromIso) || dateHasError(dateToIso)) {
+    const errors = []
+    if (dateHasError(dateFromIso)) {
+      errors.push(
+        makeErrorObject({
+          name: 'dateFrom',
+          id: 'dateFrom-day',
+          text: formatValidationErrorMessage(dateFromIso as ValidationError, 'from date'),
+        })
+      )
+    }
+    if (dateHasError(dateToIso)) {
+      errors.push(
+        makeErrorObject({
+          name: 'dateTo',
+          id: 'dateTo-day',
+          text: formatValidationErrorMessage(dateToIso as ValidationError, 'to date'),
+        })
+      )
+    }
+    return {
+      errors,
+      contacts,
+    }
+  }
+  const dateFrom = DateTime.fromISO(dateFromIso as string)
+  const dateTo = DateTime.fromISO(moveDateToEndOfDay(dateToIso as string))
+  if (dateFrom.toMillis() > dateTo.toMillis()) {
+    return {
+      errors: [
+        makeErrorObject({
+          name: 'dateFrom',
+          id: 'dateFrom-day',
+          text: formatValidationErrorMessage({ errorId: 'fromDateAfterToDate' } as ValidationError),
+        }),
+      ],
+      contacts,
+    }
+  }
+  const interval = Interval.fromDateTimes(dateFrom, dateTo)
+  return {
+    contacts: contacts.filter(contact => interval.contains(DateTime.fromISO(contact.contactStartDate))),
+    selectedLabel: `${dateFrom.toFormat('dd-MM-yyyy')} to ${dateTo.toFormat('dd-MM-yyyy')}`,
+  }
+}

--- a/server/middleware/parseUrl.test.ts
+++ b/server/middleware/parseUrl.test.ts
@@ -1,0 +1,13 @@
+import { parseUrl } from './parseUrl'
+import { mockReq, mockRes } from './testutils/mockRequestUtils'
+
+describe('parseUrl', () => {
+  it('saves request path to urlInfo object on res.locals', () => {
+    const path = '/test'
+    const req = mockReq({ originalUrl: '/test?q=1', path })
+    const res = mockRes()
+    const next = jest.fn()
+    parseUrl(req, res, next)
+    expect(res.locals.urlInfo.path).toEqual(path)
+  })
+})

--- a/server/middleware/parseUrl.ts
+++ b/server/middleware/parseUrl.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from 'express'
+
+export const parseUrl = (req: Request, res: Response, next: NextFunction) => {
+  res.locals.urlInfo = {
+    path: req.path,
+  }
+  next()
+}

--- a/server/utils/dates/convert.test.ts
+++ b/server/utils/dates/convert.test.ts
@@ -1,0 +1,274 @@
+import { DateTime } from 'luxon'
+import { convertGmtDatePartsToUtc, moveDateToEndOfDay, splitIsoDateToParts } from './convert'
+import { padWithZeroes } from './format'
+
+describe('convertGmtDatePartsToUtc', () => {
+  it('returns an ISO formatted UTC date for valid date-time parts that fall within BST period', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '05', day: '30', hour: '14', minute: '12' },
+      { includeTime: true }
+    )
+    expect(result).toEqual('2021-05-30T13:12:00.000Z')
+  })
+
+  it('returns an ISO formatted UTC date for valid date parts', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2021', month: '05', day: '30' })
+    expect(result).toEqual('2021-05-30')
+  })
+
+  it('returns an ISO formatted UTC date for valid date-time parts that fall outside BST period', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '01', day: '12', hour: '11', minute: '40' },
+      { includeTime: true }
+    )
+    expect(result).toEqual('2021-01-12T11:40:00.000Z')
+  })
+
+  it('returns an ISO formatted UTC date-time for a valid date-time', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '01', day: '12', hour: '10', minute: '53' },
+      { includeTime: true }
+    )
+    expect(result).toEqual('2021-01-12T10:53:00.000Z')
+  })
+
+  it('returns an ISO formatted UTC date for a valid date', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2021', month: '01', day: '12' })
+    expect(result).toEqual('2021-01-12')
+  })
+
+  it('returns an error for a date with all parts missing', () => {
+    const result = convertGmtDatePartsToUtc({ year: '', month: '', day: '' })
+    expect(result).toEqual({ errorId: 'blankDateTime' })
+  })
+
+  it('returns an error for a date-time with all parts missing', () => {
+    const result = convertGmtDatePartsToUtc({ year: '', month: '', day: '', hour: '', minute: '' })
+    expect(result).toEqual({ errorId: 'blankDateTime' })
+  })
+
+  it('returns an error for a date with any part missing', () => {
+    const result = convertGmtDatePartsToUtc({ year: '', month: '3', day: '20' })
+    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['year'] })
+  })
+
+  it('returns an error for a date-time with any part not being an integer', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: 'ff21', month: '3.2', day: '-0.5', hour: 'ab1', minute: '-100' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'invalidDate' })
+  })
+
+  it('returns an error for a date with any part over the max allowed value', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2020', month: '32', day: '45' })
+    expect(result).toEqual({ errorId: 'invalidDate' })
+  })
+
+  it('returns an error for a date with the year below the minimum value', () => {
+    const result = convertGmtDatePartsToUtc({ year: '1899', month: '10', day: '12' })
+    expect(result).toEqual({ errorId: 'minValueDateYear' })
+  })
+
+  it('returns undefined for a 29 Feb date not in a leap year', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2021', month: '02', day: '29' })
+    expect(result).toEqual({ errorId: 'invalidDate' })
+  })
+
+  it('returns an ISO formatted UTC date for a 29 Feb date in a leap year', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2020', month: '02', day: '29' })
+    expect(result).toEqual('2020-02-29')
+  })
+
+  it('returns an error for a date with any date part having a negative value', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2020', month: '-5', day: '12' })
+    expect(result).toEqual({ errorId: 'invalidDate' })
+  })
+
+  it('returns an error for a date-time with any hour part having a negative value', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2020', month: '05', day: '12', hour: '-10', minute: '53' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'invalidTime' })
+  })
+
+  it('returns an error for a date-time with any hour part over the max allowed value', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2020', month: '05', day: '12', hour: '24', minute: '53' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'invalidTime' })
+  })
+
+  it('returns an error for a date-time with any minute part having a negative value', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2020', month: '05', day: '12', hour: '-10', minute: '53' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'invalidTime' })
+  })
+
+  it('returns an error for a date-time with any minute part having a value out of bounds', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2020', month: '05', day: '12', hour: '23', minute: '60' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'invalidTime' })
+  })
+
+  it('returns an error for a date-time with parts missing from date and time', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '', month: '03', day: '20', hour: '', minute: '05' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['year', 'hour'] })
+  })
+
+  it('returns an error for a date with any parts missing', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2021', month: '', day: '' })
+    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['day', 'month'] })
+  })
+
+  it('returns an error for a date-time with all date parts missing', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '', month: '', day: '', hour: '03', minute: '04' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'missingDate' })
+  })
+
+  it('returns an error for a date-time with any time parts missing', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '03', day: '25', hour: '05', minute: '' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['minute'] })
+  })
+
+  it('returns an error for a date-time with all time parts missing', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '03', day: '25', hour: '', minute: '' },
+      { includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'missingTime' })
+  })
+
+  it('returns an error if a date-time must be in the past but is in the future', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2050', month: '12', day: '10', hour: '23', minute: '12' },
+      { dateMustBeInPast: true, includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'dateMustBeInPast' })
+  })
+
+  it('returns an error if a date must be in the past but is in the future', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2045', month: '03', day: '04' },
+      { dateMustBeInPast: true, includeTime: false }
+    )
+    expect(result).toEqual({ errorId: 'dateMustBeInPast' })
+  })
+
+  it('returns valid date string if a date must be in the past and is today', () => {
+    const today = DateTime.now()
+    const { year, month, day } = today
+    const result = convertGmtDatePartsToUtc(
+      { year: year.toString(), month: padWithZeroes(month), day: padWithZeroes(day) },
+      { dateMustBeInPast: true, includeTime: false }
+    )
+    expect(result).toEqual(today.toISODate())
+  })
+
+  it('returns an error if a date-time must be in the future but is in the past', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2020', month: '12', day: '10', hour: '23', minute: '12' },
+      { dateMustBeInFuture: true, includeTime: true }
+    )
+    expect(result).toEqual({ errorId: 'dateMustBeInFuture' })
+  })
+
+  it('returns an error if a date must be in the future but is in the past', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2020', month: '03', day: '04' },
+      { dateMustBeInFuture: true, includeTime: false }
+    )
+    expect(result).toEqual({ errorId: 'dateMustBeInFuture' })
+  })
+
+  it('allows single-digit parts if validatePartLengths option is not passed', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '3', day: '5', hour: '5', minute: '1' },
+      { includeTime: true }
+    )
+    expect(result).toEqual('2021-03-05T05:01:00.000Z')
+  })
+
+  it('returns an error for a date-time with any single-digit parts not padded with zeroes, if validatePartLengths option is passed', () => {
+    const result = convertGmtDatePartsToUtc(
+      { year: '2021', month: '3', day: '5', hour: '5', minute: '1' },
+      { includeTime: true, validatePartLengths: true }
+    )
+    expect(result).toEqual({ errorId: 'minLengthDateTimeParts', invalidParts: ['day', 'month', 'hour', 'minute'] })
+  })
+
+  it('returns an error for a date with any single-digit parts not padded with zeroes, if validatePartLengths option is passed', () => {
+    const result = convertGmtDatePartsToUtc({ year: '2021', month: '3', day: '5' }, { validatePartLengths: true })
+    expect(result).toEqual({ errorId: 'minLengthDateParts', invalidParts: ['day', 'month'] })
+  })
+
+  it('returns an error for a year of less than 4 digits, if validatePartLengths option is passed', () => {
+    const result = convertGmtDatePartsToUtc({ year: '21', month: '03', day: '05' }, { validatePartLengths: true })
+    expect(result).toEqual({ errorId: 'minLengthDateParts', invalidParts: ['year'] })
+  })
+})
+
+describe('splitIsoDateToParts', () => {
+  it('returns date parts for a given ISO date-time string, with hours corrected if inside DST', () => {
+    const result = splitIsoDateToParts('2021-05-30T13:12:00.000Z')
+    expect(result).toEqual({
+      day: '30',
+      hour: '14',
+      minute: '12',
+      month: '05',
+      year: '2021',
+    })
+  })
+
+  it('returns date parts for a given ISO date-time string, with hours not corrected if outside DST', () => {
+    const result = splitIsoDateToParts('2021-11-12T08:43:00.000Z')
+    expect(result).toEqual({
+      day: '12',
+      hour: '08',
+      minute: '43',
+      month: '11',
+      year: '2021',
+    })
+  })
+
+  it('returns date parts for a given ISO date string', () => {
+    const result = splitIsoDateToParts('2021-05-30')
+    expect(result).toEqual({
+      day: '30',
+      month: '05',
+      year: '2021',
+    })
+  })
+
+  it('returns undefined if passed an empty date string', () => {
+    const result = splitIsoDateToParts()
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('moveDateToEndOfDay', () => {
+  it('sets the timestamp for a date to 23:59', () => {
+    const result = moveDateToEndOfDay('2022-10-05')
+    expect(result).toEqual('2022-10-05T23:59:59.999Z')
+  })
+
+  it('adjusts an existing timestamp to 23:59', () => {
+    const result = moveDateToEndOfDay('2022-10-05T08:43:29.000Z')
+    expect(result).toEqual('2022-10-05T23:59:59.999Z')
+  })
+})

--- a/server/utils/dates/convert.ts
+++ b/server/utils/dates/convert.ts
@@ -1,0 +1,170 @@
+import { DateTime } from 'luxon'
+import { DatePartNames, DatePartsParsed, DateTimePart, ValidationError } from '../../@types/dates'
+import { ObjectMap } from '../../@types'
+import { padWithZeroes } from './format'
+import logger from '../../../logger'
+import { areStringArraysTheSame, isDefined } from '../utils'
+import { europeLondon, getDateTimeInEuropeLondon } from './index'
+
+interface Options {
+  includeTime?: boolean
+  dateMustBeInPast?: boolean
+  dateMustBeInFuture?: boolean
+  validatePartLengths?: boolean
+}
+
+const filterPartsForEmptyStrings = (parts: unknown[]): DatePartNames[] =>
+  parts.map(({ name, value }) => (value === '' ? name : undefined)).filter(Boolean)
+
+const filterPartsForMinimumLength = (parts: unknown[]): DatePartNames[] =>
+  parts.map(({ name, value, minLength }) => (value.length < (minLength || 2) ? name : undefined)).filter(Boolean)
+
+export const MIN_VALUE_YEAR = 1900
+
+export const convertGmtDatePartsToUtc = (
+  { year, month, day, hour, minute }: ObjectMap<string | undefined>,
+  options: Options = {}
+): string | ValidationError => {
+  if ([year, month, day, hour, minute].every(part => !isDefined(part) || part === '')) {
+    return {
+      errorId: 'blankDateTime',
+    }
+  }
+  const dateParts = [
+    { name: 'day', value: day },
+    { name: 'month', value: month },
+    { name: 'year', value: year, minLength: 4 },
+  ]
+  let timeParts = [] as DateTimePart[]
+  if (options.includeTime) {
+    timeParts = [
+      { name: 'hour', value: hour },
+      { name: 'minute', value: minute },
+    ]
+    let dateTimePartErrors = filterPartsForEmptyStrings([...dateParts, ...timeParts])
+    if (dateTimePartErrors.length) {
+      if (areStringArraysTheSame(dateTimePartErrors, ['day', 'month', 'year'])) {
+        return {
+          errorId: 'missingDate',
+        }
+      }
+      if (areStringArraysTheSame(dateTimePartErrors, ['hour', 'minute'])) {
+        return {
+          errorId: 'missingTime',
+        }
+      }
+      return {
+        errorId: 'missingDateParts',
+        invalidParts: dateTimePartErrors,
+      }
+    }
+    if (options.validatePartLengths) {
+      dateTimePartErrors = filterPartsForMinimumLength([...dateParts, ...timeParts])
+      if (dateTimePartErrors.length) {
+        return {
+          errorId: 'minLengthDateTimeParts',
+          invalidParts: dateTimePartErrors,
+        }
+      }
+    }
+  }
+  let datePartErrors = filterPartsForEmptyStrings(dateParts)
+  if (datePartErrors.length) {
+    return {
+      errorId: 'missingDateParts',
+      invalidParts: datePartErrors,
+    }
+  }
+
+  if (options.validatePartLengths) {
+    datePartErrors = filterPartsForMinimumLength(dateParts)
+    if (datePartErrors.length) {
+      return {
+        errorId: 'minLengthDateParts',
+        invalidParts: datePartErrors,
+      }
+    }
+  }
+
+  const [d, m, y, h, min] = [...dateParts, ...timeParts].map(({ value }) => {
+    return parseInt(value, 10)
+  })
+  if (y < MIN_VALUE_YEAR) {
+    return {
+      errorId: 'minValueDateYear',
+    }
+  }
+  try {
+    DateTime.fromObject(
+      {
+        year: y,
+        month: m,
+        day: d,
+      },
+      { zone: europeLondon }
+    )
+  } catch (err) {
+    return { errorId: 'invalidDate' }
+  }
+  if (options.includeTime) {
+    try {
+      DateTime.fromObject(
+        {
+          hour: h,
+          minute: min,
+        },
+        { zone: europeLondon }
+      )
+    } catch (err) {
+      return { errorId: 'invalidTime' }
+    }
+  }
+  const date = DateTime.fromObject(
+    {
+      year: y,
+      month: m,
+      day: d,
+      hour: h,
+      minute: min,
+    },
+    { zone: europeLondon }
+  )
+  if (options) {
+    const now = DateTime.now()
+    if (options.dateMustBeInPast === true && now < date) {
+      return { errorId: 'dateMustBeInPast' }
+    }
+    if (options.dateMustBeInFuture === true && now > date) {
+      return { errorId: 'dateMustBeInFuture' }
+    }
+  }
+  if (options.includeTime) {
+    return date.setZone('utc').toString()
+  }
+  return date.toISODate()
+}
+
+export const splitIsoDateToParts = (isoDate?: string): DatePartsParsed | undefined => {
+  if (!isDefined(isoDate)) {
+    return undefined
+  }
+  try {
+    const includeTime = isoDate.length > 10
+    const dateTime = getDateTimeInEuropeLondon(isoDate)
+    const { year, month, day, hour, minute } = dateTime.toObject()
+    const paddedDate = { year: year.toString(), month: padWithZeroes(month), day: padWithZeroes(day) }
+    if (includeTime) {
+      return { ...paddedDate, hour: padWithZeroes(hour), minute: padWithZeroes(minute) }
+    }
+    return paddedDate
+  } catch (err) {
+    logger.error(err)
+    return undefined
+  }
+}
+
+export const dateHasError = (field: string | ValidationError) => Boolean((field as ValidationError).errorId)
+
+export const moveDateToEndOfDay = (isoDate: string) => {
+  return DateTime.fromISO(isoDate).endOf('day').toISO()
+}

--- a/server/utils/dates/index.ts
+++ b/server/utils/dates/index.ts
@@ -1,11 +1,13 @@
 import { DateTime, Settings } from 'luxon'
 import { getProperty } from '../utils'
+import { ValidationError } from '../../@types/dates'
 
 Settings.throwOnInvalid = true
+Settings.defaultZone = 'utc'
 
 export const getDateProperty = <T>(obj: T, dateKey: string) => {
   const val = getProperty<T, string>(obj, dateKey)
-  return val ? DateTime.fromISO(val, { zone: 'utc' }) : undefined
+  return val ? DateTime.fromISO(val) : undefined
 }
 
 export const diffDatesForSort = (dateA: DateTime, dateB: DateTime, newestFirst = true) => {
@@ -40,6 +42,9 @@ export const sortListByDateField = <T>({
     return diffDatesForSort(dateA, dateB, newestFirst)
   })
 }
+
+export const dateHasError = (field: string | ValidationError) => Boolean((field as ValidationError).errorId)
+
 export const europeLondon = 'Europe/London'
 
 export function getDateTimeUTC(isoDate: string) {

--- a/server/utils/errors.test.ts
+++ b/server/utils/errors.test.ts
@@ -1,4 +1,4 @@
-import { makeErrorObject, transformErrorMessages } from './errors'
+import { formatValidationErrorMessage, makeErrorObject, transformErrorMessages } from './errors'
 
 describe('Error messages', () => {
   describe('makeErrorObject', () => {
@@ -63,6 +63,56 @@ describe('Error messages', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('formatValidationErrorMessage', () => {
+    it('renders "blankDateTime" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'blankDateTime' }, 'date of sentence')
+      expect(error).toEqual('Enter the date of sentence')
+    })
+
+    it('renders "dateMustBeInPast" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'dateMustBeInPast' }, 'date of sentence')
+      expect(error).toEqual('The date of sentence must be today or in the past')
+    })
+
+    it('renders "dateMustBeInFuture" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'dateMustBeInFuture' }, 'date of sentence')
+      expect(error).toEqual('The date of sentence must be in the future')
+    })
+
+    it('renders "invalidDate" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'invalidDate' }, 'date of sentence')
+      expect(error).toEqual('The date of sentence must be a real date')
+    })
+
+    it('renders "missingDateParts" error', () => {
+      const error = formatValidationErrorMessage(
+        { errorId: 'missingDateParts', invalidParts: ['month'] },
+        'date of sentence'
+      )
+      expect(error).toEqual('The date of sentence must include a month')
+    })
+
+    it('renders "missingDate" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'missingDate' }, 'date and time of email')
+      expect(error).toEqual('The date and time of email must include a date')
+    })
+
+    it('renders "missingTime" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'missingTime' }, 'date and time of email')
+      expect(error).toEqual('The date and time of email must include a time')
+    })
+
+    it('renders "minLengthDateTimeParts" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'minLengthDateTimeParts' }, 'date and time of receipt')
+      expect(error).toEqual('The date and time of receipt must be in the correct format, like 06 05 2021 09:03')
+    })
+
+    it('renders "minLengthDateParts" error', () => {
+      const error = formatValidationErrorMessage({ errorId: 'minLengthDateParts' }, 'date of sentence')
+      expect(error).toEqual('The date of sentence must be in the correct format, like 06 05 2021')
     })
   })
 })

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -1,4 +1,6 @@
 import { FormError, KeyedFormErrors, NamedFormError, ObjectMap } from '../@types'
+import { ValidationError } from '../@types/dates'
+import { listToString } from './utils'
 
 export const makeErrorObject = ({
   id,
@@ -27,4 +29,33 @@ export const transformErrorMessages = (errors: NamedFormError[]): KeyedFormError
     list: errors,
     ...errorMap,
   } as KeyedFormErrors
+}
+
+export const formatValidationErrorMessage = (validationError: ValidationError, fieldLabel?: string): string => {
+  switch (validationError.errorId) {
+    case 'blankDateTime':
+      return `Enter the ${fieldLabel}`
+    case 'dateMustBeInPast':
+      return `The ${fieldLabel} must be today or in the past`
+    case 'dateMustBeInFuture':
+      return `The ${fieldLabel} must be in the future`
+    case 'invalidDate':
+      return `The ${fieldLabel} must be a real date`
+    case 'invalidTime':
+      return `The ${fieldLabel} must be a real time`
+    case 'missingDate':
+      return `The ${fieldLabel} must include a date`
+    case 'missingTime':
+      return `The ${fieldLabel} must include a time`
+    case 'missingDateParts':
+      return `The ${fieldLabel} must include a ${listToString(validationError.invalidParts, 'and')}`
+    case 'minLengthDateTimeParts':
+      return `The ${fieldLabel} must be in the correct format, like 06 05 2021 09:03`
+    case 'minLengthDateParts':
+      return `The ${fieldLabel} must be in the correct format, like 06 05 2021`
+    case 'fromDateAfterToDate':
+      return 'The from date must be before the to date'
+    default:
+      return `Error - ${fieldLabel}`
+  }
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -29,6 +29,8 @@ export const isString = (val: unknown) => typeof val === 'string'
 
 export const isNumber = (val: unknown) => typeof val === 'number'
 
+export const areStringArraysTheSame = (arr1: unknown[], arr2: unknown[]) => arr1.join('') === arr2.join('')
+
 export const formatSingleLineAddress = (address: Address) => {
   const parts = ['line1', 'line2', 'town', 'postcode'].map(key => address[key]).filter(Boolean)
   return listToString(parts, '')


### PR DESCRIPTION
These will be used by the next PR, to filter licence history contacts by date range.

Utils:
- filterContactsByDateRange
- parseUrl - make URL components available to views
- convertGmtDatePartsToUtc - convert the day/month/year that was entered into a date input, to a ISO string or error object
- formatValidationErrorMessage - render an error message using a validation error code