### PR TITLE
MRD-148 - Filter licence history contacts by date range (under a feature flag)

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -23,3 +23,7 @@ pre.govuk-body {
 .no-max-width {
   max-width: none;
 }
+
+.govuk-date-input__item:last-child {
+  margin-right: 0;
+}

--- a/cypress_shared/commands.ts
+++ b/cypress_shared/commands.ts
@@ -1,4 +1,5 @@
 import { exactMatchIgnoreWhitespace } from './utils'
+import { splitIsoDateToParts } from '../server/utils/dates/convert'
 
 Cypress.Commands.add('pageHeading', () =>
   cy
@@ -83,9 +84,9 @@ Cypress.Commands.add('getDefinitionListValue', (label: string, opts = { parent: 
     .then(text => text.trim())
 )
 
-Cypress.Commands.add('assertErrorMessage', ({ fieldId, errorText }) => {
-  cy.get(`[href="#${fieldId}"]`).should('have.text', errorText)
-  cy.get(`#${fieldId}-error`)
+Cypress.Commands.add('assertErrorMessage', ({ fieldGroupId, fieldName, errorText }) => {
+  cy.get(`[href="#${fieldGroupId || fieldName}"]`).should('have.text', errorText)
+  cy.get(`#${fieldName}-error`)
     .invoke('text')
     .then(text => expect(text.trim()).to.contain(errorText))
 })
@@ -117,4 +118,16 @@ Cypress.Commands.add('selectRadio', (groupLabel, value, opts = { parent: 'body' 
     .then($fieldset => {
       cy.wrap($fieldset).contains('label', value).click()
     })
+})
+
+Cypress.Commands.add('enterDateTime', (isoDateTime, opts = { parent: '#main-content' }) => {
+  const { day, month, year, hour, minute } = splitIsoDateToParts(isoDateTime)
+  const options = { ...opts, clearExistingText: true }
+  cy.fillInput('Day', day, options)
+  cy.fillInput('Month', month, options)
+  cy.fillInput('Year', year, options)
+  if (isoDateTime.length > 10) {
+    cy.fillInput('Hour', hour, options)
+    cy.fillInput('Minute', minute, options)
+  }
 })

--- a/cypress_shared/index.d.ts
+++ b/cypress_shared/index.d.ts
@@ -46,7 +46,7 @@ declare global {
 
       getDefinitionListValue(label: string, opts?: CommandOpts): Chainable<string>
 
-      assertErrorMessage(args: { fieldGroupId: string; fieldName?: string; errorText: string })
+      assertErrorMessage(args: { fieldGroupId?: string; fieldName?: string; errorText: string })
     }
   }
 }

--- a/cypress_shared/index.d.ts
+++ b/cypress_shared/index.d.ts
@@ -30,6 +30,8 @@ declare global {
 
       getTextInputValue(label: string, opts?: CommandOpts): Chainable<string>
 
+      enterDateTime(isoDateTime: string, opts?: CommandOpts): Chainable<void>
+
       clickButton(label: string, opts?: CommandOpts): Chainable<Element>
 
       clickLink(label: string, opts?: CommandOpts): Chainable<Element>
@@ -44,7 +46,7 @@ declare global {
 
       getDefinitionListValue(label: string, opts?: CommandOpts): Chainable<string>
 
-      assertErrorMessage(args: { fieldId: string; errorText: string })
+      assertErrorMessage(args: { fieldGroupId: string; fieldName?: string; errorText: string })
     }
   }
 }

--- a/integration_tests/integration/caseSummary.spec.ts
+++ b/integration_tests/integration/caseSummary.spec.ts
@@ -2,21 +2,19 @@ import getCaseOverviewResponse from '../../api/responses/get-case-overview.json'
 import getCasePersonalDetailsResponse from '../../api/responses/get-case-personal-details.json'
 import getCaseRiskResponse from '../../api/responses/get-case-risk.json'
 import getCaseLicenceHistoryResponse from '../../api/responses/get-case-licence-history.json'
-import { sortListByDateField } from '../../server/utils/dates'
 import { routeUrls } from '../../server/routes/routeUrls'
 import { formatDateTimeFromIsoString } from '../../server/utils/dates/format'
-import { dedupeList } from '../../server/utils/utils'
 
 context('Case summary', () => {
   beforeEach(() => {
     cy.signIn()
+    cy.task('getCase', { sectionId: 'overview', statusCode: 200, response: getCaseOverviewResponse })
     cy.task('getCase', { sectionId: 'risk', statusCode: 200, response: getCaseRiskResponse })
     cy.task('getCase', { sectionId: 'personal-details', statusCode: 200, response: getCasePersonalDetailsResponse })
     cy.task('getCase', { sectionId: 'all-licence-history', statusCode: 200, response: getCaseLicenceHistoryResponse })
   })
 
   it('can view the overview page with a list of offences', () => {
-    cy.task('getCase', { sectionId: 'overview', statusCode: 200, response: getCaseOverviewResponse })
     const crn = 'X34983'
     cy.visit(`${routeUrls.cases}/${crn}/overview`)
     cy.pageHeading().should('equal', 'Overview')
@@ -118,58 +116,6 @@ context('Case summary', () => {
     cy.clickLink('Open all')
     cy.getElement('RSR HIGH 18').should('be.visible')
     cy.getElement('RSR MEDIUM 12').should('be.visible')
-  })
-
-  it('can view the licence history page', () => {
-    const crn = 'X34983'
-    cy.visit(`${routeUrls.cases}/${crn}/licence-history`)
-    cy.pageHeading().should('equal', 'Licence history')
-
-    // contacts
-    const systemGeneratedRemoved = getCaseLicenceHistoryResponse.contactSummary.filter(
-      contact => contact.systemGenerated === false
-    )
-    const sortedByDate = sortListByDateField({
-      list: systemGeneratedRemoved,
-      dateKey: 'contactStartDate',
-      newestFirst: true,
-    })
-    const dates = []
-    sortedByDate.forEach((contact, index) => {
-      dates.push(contact.contactStartDate.substring(0, 10))
-      const opts = { parent: `[data-qa="contact-${index}"]` }
-      cy.getText('heading', opts).should('equal', contact.descriptionType)
-      cy.getText('time', opts).should(
-        'contain',
-        formatDateTimeFromIsoString({ isoDate: contact.contactStartDate, timeOnly: true })
-      )
-      cy.getText('notes', opts).should('equal', contact.notes)
-    })
-    const dedupedDates = dedupeList(dates)
-    dedupedDates.forEach((date, index) => {
-      cy.getText(`date-${index}`).should('equal', formatDateTimeFromIsoString({ isoDate: date, dateOnly: true }))
-    })
-  })
-
-  it('can view collapsible notes on the licence history page', () => {
-    const crn = 'X34983'
-    cy.visit(`${routeUrls.cases}/${crn}/licence-history?collapsibleNotes=1`)
-
-    // contacts
-    const systemGeneratedRemoved = getCaseLicenceHistoryResponse.contactSummary.filter(
-      contact => contact.systemGenerated === false
-    )
-    const sortedByDate = sortListByDateField({
-      list: systemGeneratedRemoved,
-      dateKey: 'contactStartDate',
-      newestFirst: true,
-    })
-    const dates = []
-    sortedByDate.forEach((contact, index) => {
-      dates.push(contact.contactStartDate.substring(0, 10))
-      const opts = { parent: `[data-qa="contact-${index}"]` }
-      cy.viewDetails('View more detail', opts).should('equal', contact.notes)
-    })
   })
 
   it('can switch between case summary pages', () => {

--- a/integration_tests/integration/licenceHistory.spec.ts
+++ b/integration_tests/integration/licenceHistory.spec.ts
@@ -1,0 +1,129 @@
+import { DateTime } from 'luxon'
+import getCaseOverviewResponse from '../../api/responses/get-case-overview.json'
+import getCasePersonalDetailsResponse from '../../api/responses/get-case-personal-details.json'
+import getCaseRiskResponse from '../../api/responses/get-case-risk.json'
+import getCaseLicenceHistoryResponse from '../../api/responses/get-case-licence-history.json'
+import { europeLondon, sortListByDateField } from '../../server/utils/dates'
+import { routeUrls } from '../../server/routes/routeUrls'
+import { formatDateTimeFromIsoString } from '../../server/utils/dates/format'
+import { dedupeList } from '../../server/utils/utils'
+
+context('Licence history', () => {
+  beforeEach(() => {
+    cy.signIn()
+    cy.task('getCase', { sectionId: 'overview', statusCode: 200, response: getCaseOverviewResponse })
+    cy.task('getCase', { sectionId: 'risk', statusCode: 200, response: getCaseRiskResponse })
+    cy.task('getCase', { sectionId: 'personal-details', statusCode: 200, response: getCasePersonalDetailsResponse })
+    cy.task('getCase', { sectionId: 'all-licence-history', statusCode: 200, response: getCaseLicenceHistoryResponse })
+  })
+
+  it('can view the licence history page', () => {
+    const crn = 'X34983'
+    cy.visit(`${routeUrls.cases}/${crn}/licence-history`)
+    cy.pageHeading().should('equal', 'Licence history')
+
+    // contacts
+    const systemGeneratedRemoved = getCaseLicenceHistoryResponse.contactSummary.filter(
+      contact => contact.systemGenerated === false
+    )
+    const sortedByDate = sortListByDateField({
+      list: systemGeneratedRemoved,
+      dateKey: 'contactStartDate',
+      newestFirst: true,
+    })
+    const dates = []
+    sortedByDate.forEach((contact, index) => {
+      dates.push(DateTime.fromISO(contact.contactStartDate, { zone: europeLondon }).toISODate())
+      const opts = { parent: `[data-qa="contact-${index}"]` }
+      cy.getText('heading', opts).should('equal', contact.descriptionType)
+      cy.getText('time', opts).should(
+        'contain',
+        formatDateTimeFromIsoString({ isoDate: contact.contactStartDate, timeOnly: true })
+      )
+      cy.getText('notes', opts).should('equal', contact.notes)
+    })
+    const dedupedDates = dedupeList(dates)
+    dedupedDates.forEach((date, index) => {
+      cy.getText(`date-${index}`).should('equal', formatDateTimeFromIsoString({ isoDate: date, dateOnly: true }))
+    })
+  })
+
+  it('can view collapsible notes on the licence history page', () => {
+    const crn = 'X34983'
+    cy.visit(`${routeUrls.cases}/${crn}/licence-history?collapsibleNotes=1`)
+
+    // contacts
+    const systemGeneratedRemoved = getCaseLicenceHistoryResponse.contactSummary.filter(
+      contact => contact.systemGenerated === false
+    )
+    const sortedByDate = sortListByDateField({
+      list: systemGeneratedRemoved,
+      dateKey: 'contactStartDate',
+      newestFirst: true,
+    })
+    const dates = []
+    sortedByDate.forEach((contact, index) => {
+      dates.push(contact.contactStartDate.substring(0, 10))
+      const opts = { parent: `[data-qa="contact-${index}"]` }
+      cy.viewDetails('View more detail', opts).should('equal', contact.notes)
+    })
+  })
+
+  it('can filter licence history contacts by date range', () => {
+    const crn = 'X34983'
+    cy.visit(`${routeUrls.cases}/${crn}/licence-history?dateFilters=1`)
+
+    // apply filters without entering dates
+    cy.clickButton('Apply filters')
+    cy.getElement('5 contacts').should('exist')
+
+    // invalid dates - part of date missing
+    cy.fillInput('Day', '12', { parent: '#dateFrom' })
+    cy.fillInput('Month', '04', { parent: '#dateFrom' })
+    cy.fillInput('Year', '2022', { parent: '#dateTo' })
+    cy.clickButton('Apply filters')
+    cy.assertErrorMessage({
+      fieldGroupId: 'dateFrom-day',
+      fieldName: 'dateFrom',
+      errorText: 'The from date must include a year',
+    })
+    cy.assertErrorMessage({
+      fieldGroupId: 'dateTo-day',
+      fieldName: 'dateTo',
+      errorText: 'The to date must include a day and month',
+    })
+    cy.getElement('5 contacts').should('exist')
+
+    // invalid dates - from date after to date
+    cy.enterDateTime('2022-04-14', { parent: '#dateFrom' })
+    cy.enterDateTime('2022-04-13', { parent: '#dateTo' })
+    cy.clickButton('Apply filters')
+    cy.assertErrorMessage({
+      fieldGroupId: 'dateFrom-day',
+      fieldName: 'dateFrom',
+      errorText: 'The from date must be before the to date',
+    })
+
+    // invalid date - out of bounds value
+    cy.fillInput('Day', '36', { parent: '#dateFrom', clearExistingText: true })
+    cy.fillInput('Month', '04', { parent: '#dateFrom', clearExistingText: true })
+    cy.fillInput('Year', '2021', { parent: '#dateFrom', clearExistingText: true })
+    cy.clickButton('Apply filters')
+    cy.assertErrorMessage({
+      fieldGroupId: 'dateFrom-day',
+      fieldName: 'dateFrom',
+      errorText: 'The from date must be a real date',
+    })
+
+    // successful date filter
+    cy.enterDateTime('2022-03-13', { parent: '#dateFrom' })
+    cy.enterDateTime('2022-04-13', { parent: '#dateTo' })
+    cy.clickButton('Apply filters')
+    cy.getElement('2 contacts').should('exist')
+    cy.getLinkHref('13-03-2022 to 13-04-2022').should('equal', `/cases/${crn}/licence-history`)
+
+    // clear filters
+    cy.clickLink('Clear filters')
+    cy.getElement('5 contacts').should('exist')
+  })
+})

--- a/integration_tests/integration/licenceHistory.spec.ts
+++ b/integration_tests/integration/licenceHistory.spec.ts
@@ -120,7 +120,7 @@ context('Licence history', () => {
     cy.enterDateTime('2022-04-13', { parent: '#dateTo' })
     cy.clickButton('Apply filters')
     cy.getElement('2 contacts').should('exist')
-    cy.getLinkHref('13-03-2022 to 13-04-2022').should('equal', `/cases/${crn}/licence-history`)
+    cy.getLinkHref('13-03-2022 to 13-04-2022').should('equal', `/cases/${crn}/licence-history?dateFilters=1`)
 
     // clear filters
     cy.clickLink('Clear filters')

--- a/integration_tests/integration/personSearch.spec.ts
+++ b/integration_tests/integration/personSearch.spec.ts
@@ -25,7 +25,7 @@ context('Search for a person', () => {
     // no search term entered
     cy.clickButton('Search')
     cy.assertErrorMessage({
-      fieldId: 'crn',
+      fieldGroupId: 'crn',
       errorText: 'Enter a Case Reference Number (CRN)',
     })
 

--- a/integration_tests/integration/personSearch.spec.ts
+++ b/integration_tests/integration/personSearch.spec.ts
@@ -25,7 +25,7 @@ context('Search for a person', () => {
     // no search term entered
     cy.clickButton('Search')
     cy.assertErrorMessage({
-      fieldGroupId: 'crn',
+      fieldName: 'crn',
       errorText: 'Enter a Case Reference Number (CRN)',
     })
 

--- a/server/controllers/caseSummary/caseSummary.ts
+++ b/server/controllers/caseSummary/caseSummary.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express'
 import { isString } from '../../utils/utils'
 import { CaseSectionId } from '../../@types'
-import { getCaseSection } from './utils'
+import { getCaseSection } from './utils/getCaseSection'
+import { transformErrorMessages } from '../../utils/errors'
 
 export const caseSummary = async (req: Request, res: Response): Promise<Response | void> => {
   const { crn, sectionId } = req.params
@@ -9,7 +10,15 @@ export const caseSummary = async (req: Request, res: Response): Promise<Response
     return res.sendStatus(400)
   }
   const crnFormatted = (crn as string).toUpperCase()
-  const caseSection = await getCaseSection(sectionId as CaseSectionId, crnFormatted, res.locals.user.token, req.query)
+  const { errors, ...caseSection } = await getCaseSection(
+    sectionId as CaseSectionId,
+    crnFormatted,
+    res.locals.user.token,
+    req.query
+  )
+  if (errors) {
+    res.locals.errors = transformErrorMessages(errors)
+  }
   res.locals = {
     ...res.locals,
     ...caseSection,

--- a/server/controllers/caseSummary/utils/groupContactsByStartDate.test.ts
+++ b/server/controllers/caseSummary/utils/groupContactsByStartDate.test.ts
@@ -1,5 +1,5 @@
-import { groupContactsByStartDate } from './licenceHistory'
 import { ContactSummary } from '../../../@types/make-recall-decision-api/models/ContactSummary'
+import { groupContactsByStartDate } from './groupContactsByStartDate'
 
 describe('groupContactsByStartDate', () => {
   it('returns a list grouped by start date', () => {
@@ -42,6 +42,39 @@ describe('groupContactsByStartDate', () => {
               contactStartDate: '2022-04-21T10:03:00Z',
               descriptionType: 'Management Oversight - Recall',
               startDate: '2022-04-21',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('applies daylight saving / timezone before grouping', () => {
+    const result = groupContactsByStartDate([
+      {
+        contactStartDate: '2022-07-04T23:30:00Z',
+        descriptionType: 'Planned Office Visit (NS)',
+      },
+      {
+        contactStartDate: '2022-07-05T13:07:00Z',
+        descriptionType: 'Arrest attempt',
+      },
+    ] as ContactSummary[])
+    expect(result).toEqual({
+      groupedByKey: 'startDate',
+      items: [
+        {
+          groupValue: '2022-07-05',
+          items: [
+            {
+              contactStartDate: '2022-07-05T13:07:00Z',
+              descriptionType: 'Arrest attempt',
+              startDate: '2022-07-05',
+            },
+            {
+              contactStartDate: '2022-07-04T23:30:00Z',
+              descriptionType: 'Planned Office Visit (NS)',
+              startDate: '2022-07-05',
             },
           ],
         },

--- a/server/controllers/caseSummary/utils/groupContactsByStartDate.ts
+++ b/server/controllers/caseSummary/utils/groupContactsByStartDate.ts
@@ -1,12 +1,12 @@
-import { CaseLicenceHistory } from '../../../@types/make-recall-decision-api/models/CaseLicenceHistory'
+import { DateTime } from 'luxon'
 import { ContactSummary } from '../../../@types/make-recall-decision-api/models/ContactSummary'
-import { sortListByDateField } from '../../../utils/dates'
+import { europeLondon, sortListByDateField } from '../../../utils/dates'
 import { groupListByValue } from '../../../utils/utils'
 
 export const groupContactsByStartDate = (contacts: ContactSummary[]) => {
   const contactsWithDate = contacts.map(contact => ({
     ...contact,
-    startDate: contact.contactStartDate.substring(0, 10),
+    startDate: DateTime.fromISO(contact.contactStartDate, { zone: europeLondon }).toISODate(),
   }))
   const sortedByDate = sortListByDateField({
     list: contactsWithDate,
@@ -23,14 +23,4 @@ export const groupContactsByStartDate = (contacts: ContactSummary[]) => {
     newestFirst: true,
   })
   return { ...groupedByDate, items: sortedByGroupDate }
-}
-
-export const transformLicenceHistory = (caseSummary: CaseLicenceHistory, showSystemGenerated: boolean) => {
-  const filtered = showSystemGenerated
-    ? caseSummary.contactSummary
-    : caseSummary.contactSummary.filter((contact: ContactSummary) => contact.systemGenerated === false)
-  return {
-    ...caseSummary,
-    contactSummary: groupContactsByStartDate(filtered),
-  }
 }

--- a/server/controllers/caseSummary/utils/transformLicenceHistory.test.ts
+++ b/server/controllers/caseSummary/utils/transformLicenceHistory.test.ts
@@ -1,0 +1,82 @@
+import { transformLicenceHistory } from './transformLicenceHistory'
+import { CaseLicenceHistory } from '../../../@types/make-recall-decision-api/models/CaseLicenceHistory'
+
+describe('transformLicenceHistory', () => {
+  const contactSummary = [
+    {
+      contactStartDate: '2022-05-04T13:07:00Z',
+      descriptionType: 'Arrest attempt',
+      outcome: null,
+      notes:
+        'Good afternoon, the police attempted to arrest Mr. Edwin at 18 Serata Street today, they forced entry but he was not present. We have a contractor repairing the door and changing the locks so that Mr. Edwin will not be able to return. Kind regards, PC Street',
+      enforcementAction: null,
+      systemGenerated: true,
+    },
+    {
+      contactStartDate: '2022-04-21T10:03:00Z',
+      descriptionType: 'Management Oversight - Recall',
+      outcome: 'Decision to Recall',
+      notes:
+        'Comment added by Jane Pavement on 21/04/2022 at 10:40\nEnforcement Action:  A standard recall is appropriate here because Mr. Edwin has lost his current accommodation as a result of concerns related to drug supply. There are ongoing concerns about his alcohol misuse and poor engagement with probation appointments. A standard recall will allow Mr. Edwin to address his alcohol abuse and consider most appropriate accommodation on release.',
+      enforcementAction: null,
+      systemGenerated: false,
+    },
+    {
+      contactStartDate: '2022-04-21T11:30:00Z',
+      descriptionType: 'Planned Office Visit (NS)',
+      outcome: 'Failed to Attend',
+      notes: 'Comment added by Eliot Prufrock on 20/04/2022 at 11:35\nEnforcement Action: Refer to Offender Manager',
+      enforcementAction: 'Decision Pending Response from Person on Probation',
+      systemGenerated: true,
+    },
+  ]
+
+  it('sets contacts count to the number of filtered items, and returns the selected filters', () => {
+    const { errors, data } = transformLicenceHistory({
+      caseSummary: { contactSummary } as CaseLicenceHistory,
+      filters: {
+        'dateFrom-day': '21',
+        'dateFrom-month': '04',
+        'dateFrom-year': '2022',
+        'dateTo-day': '21',
+        'dateTo-month': '04',
+        'dateTo-year': '2022',
+      },
+    })
+    expect(errors).toBeUndefined()
+    // contact count is 1 because 1 of the 3 items was filtered out as system-generated, and another by the date range
+    expect(data.contactCount).toEqual(1)
+    expect(data.filters).toEqual({
+      dateRange: {
+        dateFrom: {
+          day: '21',
+          month: '04',
+          year: '2022',
+        },
+        dateTo: {
+          day: '21',
+          month: '04',
+          year: '2022',
+        },
+        selectedLabel: '21-04-2022 to 21-04-2022',
+      },
+    })
+  })
+
+  it('returns all contacts if system generated are included, and no date filter', () => {
+    const { errors, data } = transformLicenceHistory({
+      caseSummary: { contactSummary } as CaseLicenceHistory,
+      filters: {
+        showSystemGenerated: 'YES',
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(data.contactCount).toEqual(3)
+    expect(data.filters).toEqual({
+      dateRange: {
+        dateFrom: {},
+        dateTo: {},
+      },
+    })
+  })
+})

--- a/server/controllers/caseSummary/utils/transformLicenceHistory.ts
+++ b/server/controllers/caseSummary/utils/transformLicenceHistory.ts
@@ -1,0 +1,58 @@
+import { CaseLicenceHistory } from '../../../@types/make-recall-decision-api/models/CaseLicenceHistory'
+import { ContactSummary } from '../../../@types/make-recall-decision-api/models/ContactSummary'
+import { ObjectMap } from '../../../@types'
+import { filterContactsByDateRange } from './filterContactsByDateRange'
+import { groupContactsByStartDate } from './groupContactsByStartDate'
+
+const filterSystemGenerated = ({
+  contacts,
+  showSystemGenerated,
+}: {
+  contacts: ContactSummary[]
+  showSystemGenerated?: string
+}): ContactSummary[] => {
+  if (showSystemGenerated === 'YES') {
+    return contacts
+  }
+  return contacts.filter((contact: ContactSummary) => contact.systemGenerated === false)
+}
+
+export const transformLicenceHistory = ({
+  caseSummary,
+  filters,
+}: {
+  caseSummary: CaseLicenceHistory
+  filters: ObjectMap<string>
+}) => {
+  const filteredBySystemGenerated = filterSystemGenerated({
+    contacts: caseSummary.contactSummary,
+    showSystemGenerated: filters.showSystemGenerated,
+  })
+  const { errors, contacts, selectedLabel } = filterContactsByDateRange({
+    contacts: filteredBySystemGenerated,
+    filters,
+  })
+  return {
+    errors,
+    data: {
+      ...caseSummary,
+      contactSummary: groupContactsByStartDate(contacts),
+      contactCount: contacts.length,
+      filters: {
+        dateRange: {
+          selectedLabel,
+          dateFrom: {
+            day: filters[`dateFrom-day`],
+            month: filters[`dateFrom-month`],
+            year: filters[`dateFrom-year`],
+          },
+          dateTo: {
+            day: filters[`dateTo-day`],
+            month: filters[`dateTo-month`],
+            year: filters[`dateTo-year`],
+          },
+        },
+      },
+    },
+  }
+}

--- a/server/middleware/featureFlags.ts
+++ b/server/middleware/featureFlags.ts
@@ -3,6 +3,7 @@ import { ObjectMap } from '../@types'
 
 export const featureFlagDefaults = {
   collapsibleNotes: false,
+  dateFilters: false,
 }
 
 export const readFeatureFlags = (flags: ObjectMap<boolean>) => (req: Request, res: Response, next: NextFunction) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,11 +7,12 @@ import { caseSummary } from '../controllers/caseSummary/caseSummary'
 import { getStoredSessionData } from '../middleware/getStoredSessionData'
 import { startPage } from '../controllers/startPage/startPage'
 import { featureFlagDefaults, readFeatureFlags } from '../middleware/featureFlags'
+import { parseUrl } from '../middleware/parseUrl'
 
 export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  router.use(getStoredSessionData, readFeatureFlags(featureFlagDefaults))
+  router.use(parseUrl, getStoredSessionData, readFeatureFlags(featureFlagDefaults))
   get('/', startPage)
   get('/search', personSearch)
   get('/search-results', personSearchResults)

--- a/server/utils/nunjucks.ts
+++ b/server/utils/nunjucks.ts
@@ -1,0 +1,59 @@
+import { DatePartsParsed } from '../@types/dates'
+
+export const dateTimeItems = (fieldName: string, values: DatePartsParsed, includeTime?: boolean) => {
+  const items = [
+    {
+      name: `day`,
+      label: 'Day',
+      classes: 'govuk-input--width-2',
+      attributes: {
+        maxlength: 2,
+      },
+      value: values?.day,
+    },
+    {
+      name: `month`,
+      label: 'Month',
+      classes: 'govuk-input--width-2',
+      type: 'number',
+      attributes: {
+        maxlength: 2,
+      },
+      value: values?.month,
+    },
+    {
+      name: `year`,
+      label: 'Year',
+      classes: 'govuk-input--width-4',
+      attributes: {
+        maxlength: 4,
+      },
+      value: values?.year,
+    },
+  ]
+  if (includeTime) {
+    return [
+      ...items,
+      {
+        name: `${fieldName}Hour`,
+        label: 'Hour',
+        classes: 'govuk-input--width-2',
+        type: 'number',
+        attributes: {
+          maxlength: 2,
+        },
+        value: values?.hour,
+      },
+      {
+        name: `${fieldName}Minute`,
+        label: 'Minute',
+        classes: 'govuk-input--width-2',
+        attributes: {
+          maxlength: 2,
+        },
+        value: values?.minute,
+      },
+    ]
+  }
+  return items
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -5,6 +5,7 @@ import * as pathModule from 'path'
 import { formatSingleLineAddress, makePageTitle, errorMessage } from './utils'
 import config from '../config'
 import { formatDateTimeFromIsoString } from './dates/format'
+import { dateTimeItems } from './nunjucks'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -54,4 +55,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('makePageTitle', makePageTitle)
   njkEnv.addGlobal('errorMessage', errorMessage)
   njkEnv.addGlobal('formatSingleLineAddress', formatSingleLineAddress)
+  njkEnv.addGlobal('dateTimeItems', dateTimeItems)
 }

--- a/server/views/partials/caseLicenceHistory.njk
+++ b/server/views/partials/caseLicenceHistory.njk
@@ -1,7 +1,68 @@
+{% include '../partials/error-summary.njk' %}
 <h1 class='govuk-heading-m'>Licence history</h1>
 <div class="govuk-grid-row">
+    {% if flags.dateFilters %}
+    <div class="govuk-grid-column-one-third-from-desktop">
+        {%- set filterOptionsHtml %}
+            {{ govukDateInput({
+                id: "dateFrom",
+                namePrefix: "dateFrom",
+                fieldset: {
+                    legend: {
+                        html: "Date range<span class='govuk-visually-hidden'> From</span>",
+                        classes: "govuk-fieldset__legend--s"
+                    }
+                },
+                items: dateTimeItems("dateFrom", caseSummary.filters.dateRange.dateFrom),
+                errorMessage: errorMessage(errors.dateFrom)
+            }) }}
+            {{ govukDateInput({
+                id: "dateTo",
+                namePrefix: "dateTo",
+                fieldset: {
+                    legend: {
+                        html: "<span class='govuk-visually-hidden'>Date range </span>To",
+                        classes: "govuk-fieldset__legend--s"
+                    }
+                },
+                items: dateTimeItems("dateTo", caseSummary.filters.dateRange.dateTo),
+                errorMessage: errorMessage(errors.dateTo)
+            }) }}
+        {% endset -%}
+        <form>
+            <input type='hidden' name='dateFilters' value='1' />
+            {{ mojFilter({
+                heading: {
+                    text: 'Filter'
+                },
+                selectedFilters: {
+                    heading: {
+                        text: 'Selected filters'
+                    },
+                    clearLink: {
+                        text: 'Clear filters',
+                        href: urlInfo.path
+                    },
+                    categories: [{
+                        heading: {
+                            text: 'Date range'
+                        },
+                        items: [{
+                            href: urlInfo.path,
+                            text: caseSummary.filters.dateRange.selectedLabel
+                        }]
+                    }]
+                } if caseSummary.filters.dateRange.selectedLabel else undefined,
+                optionsHtml: filterOptionsHtml
+            }) }}
+        </form>
+    </div>
+    {% endif %}
     <div class="govuk-grid-column-two-thirds-from-desktop">
         {% set innerLoopIndex = 0 %}
+        <div class='govuk-body govuk-!-margin-bottom-4 govuk-!-font-weight-bold'>{{ caseSummary.contactCount }}
+            contacts
+        </div>
         {% for group in caseSummary.contactSummary.items %}
             <div class='govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2' data-qa='date-{{ loop.index0 }}'>
                 {{ formatDateTimeFromIsoString({ isoDate: group.groupValue, dateOnly: true}) }}

--- a/server/views/partials/caseLicenceHistory.njk
+++ b/server/views/partials/caseLicenceHistory.njk
@@ -41,14 +41,14 @@
                     },
                     clearLink: {
                         text: 'Clear filters',
-                        href: urlInfo.path
+                        href: urlInfo.path + '?dateFilters=1'
                     },
                     categories: [{
                         heading: {
                             text: 'Date range'
                         },
                         items: [{
-                            href: urlInfo.path,
+                            href: urlInfo.path + '?dateFilters=1',
                             text: caseSummary.filters.dateRange.selectedLabel
                         }]
                     }]

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,6 +1,7 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk"           import govukBackLink %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/details/macro.njk"             import govukDetails %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}


### PR DESCRIPTION
- to enable the feature add `?dateFilters=1` to the URL
- filter contacts by date range
- split licence history transform functions to their own files
<img width="975" alt="image" src="https://user-images.githubusercontent.com/471250/169801565-a9afae4a-c5de-41c4-bd4c-c2d956f30b9b.png">
