### PR TITLE
MRD-148 - date filter enhancements

### DIFF
--- a/integration_tests/accessibility/accessibility.spec.ts
+++ b/integration_tests/accessibility/accessibility.spec.ts
@@ -14,6 +14,10 @@ const urls = [
   `${routeUrls.cases}/123/risk`,
   `${routeUrls.cases}/123/personal-details`,
   `${routeUrls.cases}/123/licence-history`,
+  // contact filter with valid dates
+  `${routeUrls.cases}/123/licence-history?dateFilters=1&dateFrom-day=13&dateFrom-month=4&dateFrom-year=22&dateTo-day=14&dateTo-month=4&dateTo-year=22`,
+  // contact filter with invalid dates and errors
+  `${routeUrls.cases}/123/licence-history?dateFilters=1&dateFrom-day=13&dateFrom-month=24&dateFrom-year=22&dateTo-day=14&dateTo-month=20&dateTo-year=22`,
 ]
 
 context('Accessibility (a11y) Checks', () => {

--- a/integration_tests/integration/licenceHistory.spec.ts
+++ b/integration_tests/integration/licenceHistory.spec.ts
@@ -77,13 +77,13 @@ context('Licence history', () => {
     cy.clickButton('Apply filters')
     cy.getElement('5 contacts').should('exist')
 
-    // invalid dates - part of date missing
+    cy.log('invalid dates - part of date missing')
     cy.fillInput('Day', '12', { parent: '#dateFrom' })
     cy.fillInput('Month', '04', { parent: '#dateFrom' })
     cy.fillInput('Year', '2022', { parent: '#dateTo' })
     cy.clickButton('Apply filters')
     cy.assertErrorMessage({
-      fieldGroupId: 'dateFrom-day',
+      fieldGroupId: 'dateFrom-year',
       fieldName: 'dateFrom',
       errorText: 'The from date must include a year',
     })
@@ -94,7 +94,7 @@ context('Licence history', () => {
     })
     cy.getElement('5 contacts').should('exist')
 
-    // invalid dates - from date after to date
+    cy.log('invalid dates - from date after to date')
     cy.enterDateTime('2022-04-14', { parent: '#dateFrom' })
     cy.enterDateTime('2022-04-13', { parent: '#dateTo' })
     cy.clickButton('Apply filters')
@@ -104,7 +104,7 @@ context('Licence history', () => {
       errorText: 'The from date must be before the to date',
     })
 
-    // invalid date - out of bounds value
+    cy.log('invalid date - out of bounds value')
     cy.fillInput('Day', '36', { parent: '#dateFrom', clearExistingText: true })
     cy.fillInput('Month', '04', { parent: '#dateFrom', clearExistingText: true })
     cy.fillInput('Year', '2021', { parent: '#dateFrom', clearExistingText: true })
@@ -112,15 +112,15 @@ context('Licence history', () => {
     cy.assertErrorMessage({
       fieldGroupId: 'dateFrom-day',
       fieldName: 'dateFrom',
-      errorText: 'The from date must be a real date',
+      errorText: 'The from date must have a valid value for day',
     })
 
-    // successful date filter
+    cy.log('successful date filter')
     cy.enterDateTime('2022-03-13', { parent: '#dateFrom' })
     cy.enterDateTime('2022-04-13', { parent: '#dateTo' })
     cy.clickButton('Apply filters')
     cy.getElement('2 contacts').should('exist')
-    cy.getLinkHref('13-03-2022 to 13-04-2022').should('equal', `/cases/${crn}/licence-history?dateFilters=1`)
+    cy.getLinkHref('13-03-2022 to 13-04-2022').should('equal', `/cases/${crn}/licence-history`)
 
     // clear filters
     cy.clickLink('Clear filters')

--- a/server/@types/dates.d.ts
+++ b/server/@types/dates.d.ts
@@ -19,6 +19,7 @@ export type ValidationErrorType =
   | 'minValueDateYear'
   | 'minLengthDateTimeParts'
   | 'minValueDateTimeParts'
+  | 'outOfRangeValueDateParts'
   | 'noSelectionFromList'
   | 'invalidSelectionFromList'
   | 'fromDateAfterToDate'
@@ -28,6 +29,10 @@ export type DatePartNames = 'year' | 'month' | 'day' | 'hour' | 'minute'
 export interface DateTimePart {
   name: DatePartNames
   value: string
+  numberValue?: number
+  minValue: number
+  maxValue: number
+  minLength: number
 }
 
 export interface ValidationError {

--- a/server/controllers/caseSummary/caseSummary.test.ts
+++ b/server/controllers/caseSummary/caseSummary.test.ts
@@ -111,7 +111,7 @@ describe('caseSummary', () => {
     })
     expect(res.locals.section).toEqual({
       id: 'licence-history',
-      label: 'Licence history',
+      label: '2 contacts for A1234AB - Licence history',
     })
   })
 
@@ -161,7 +161,7 @@ describe('caseSummary', () => {
     })
     expect(res.locals.section).toEqual({
       id: 'licence-history',
-      label: 'Licence history',
+      label: '1 contact for A1234AB - Licence history',
     })
   })
 

--- a/server/controllers/caseSummary/utils/filterContactsByDateRange.test.ts
+++ b/server/controllers/caseSummary/utils/filterContactsByDateRange.test.ts
@@ -138,8 +138,18 @@ describe('filterDates', () => {
       },
     })
     expect(errors).toEqual([
-      { href: '#dateFrom-day', name: 'dateFrom', text: 'The from date must be a real date', values: undefined },
-      { href: '#dateTo-day', name: 'dateTo', text: 'The to date must be a real date', values: undefined },
+      {
+        href: '#dateFrom-day',
+        name: 'dateFrom',
+        text: 'The from date must have a valid value for day',
+        values: undefined,
+      },
+      {
+        href: '#dateTo-month',
+        name: 'dateTo',
+        text: 'The to date must have a valid value for month',
+        values: undefined,
+      },
     ])
     expect(contacts).toEqual(contactList)
   })

--- a/server/controllers/caseSummary/utils/filterContactsByDateRange.ts
+++ b/server/controllers/caseSummary/utils/filterContactsByDateRange.ts
@@ -4,7 +4,7 @@ import { ValidationError } from '../../../@types/dates'
 import { convertGmtDatePartsToUtc, moveDateToEndOfDay } from '../../../utils/dates/convert'
 import { ContactSummary } from '../../../@types/make-recall-decision-api/models/ContactSummary'
 import { dateHasError } from '../../../utils/dates'
-import { formatValidationErrorMessage, makeErrorObject } from '../../../utils/errors'
+import { formatValidationErrorMessage, invalidDateInputPart, makeErrorObject } from '../../../utils/errors'
 
 const parseDateParts = ({
   fieldPrefix,
@@ -48,7 +48,7 @@ export const filterContactsByDateRange = ({
       errors.push(
         makeErrorObject({
           name: 'dateFrom',
-          id: 'dateFrom-day',
+          id: invalidDateInputPart(dateFromIso as ValidationError, 'dateFrom'),
           text: formatValidationErrorMessage(dateFromIso as ValidationError, 'from date'),
         })
       )
@@ -57,7 +57,7 @@ export const filterContactsByDateRange = ({
       errors.push(
         makeErrorObject({
           name: 'dateTo',
-          id: 'dateTo-day',
+          id: invalidDateInputPart(dateToIso as ValidationError, 'dateTo'),
           text: formatValidationErrorMessage(dateToIso as ValidationError, 'to date'),
         })
       )

--- a/server/controllers/caseSummary/utils/getCaseSection.ts
+++ b/server/controllers/caseSummary/utils/getCaseSection.ts
@@ -9,6 +9,7 @@ import { CaseLicenceConditions } from '../../../@types/make-recall-decision-api/
 import { CaseContactLog } from '../../../@types/make-recall-decision-api/models/CaseContactLog'
 import { fetchFromCacheOrApi } from '../../../data/fetchFromCacheOrApi'
 import { transformLicenceHistory } from './transformLicenceHistory'
+import { countLabel } from '../../../utils/utils'
 
 export const getCaseSection = async (sectionId: CaseSectionId, crn: string, token: string, reqQuery?: ParsedQs) => {
   let sectionLabel
@@ -42,7 +43,10 @@ export const getCaseSection = async (sectionId: CaseSectionId, crn: string, toke
       })
       errors = transformed.errors
       caseSummary = transformed.data
-      sectionLabel = 'Licence history'
+      sectionLabel = `${countLabel({
+        count: transformed.data.contactCount,
+        noun: 'contact',
+      })} for ${trimmedCrn} - Licence history`
       break
     case 'licence-conditions':
       caseSummary = await getCaseSummary<CaseLicenceConditions>(trimmedCrn, sectionId, token)

--- a/server/utils/dates/convert.test.ts
+++ b/server/utils/dates/convert.test.ts
@@ -3,223 +3,270 @@ import { convertGmtDatePartsToUtc, moveDateToEndOfDay, splitIsoDateToParts } fro
 import { padWithZeroes } from './format'
 
 describe('convertGmtDatePartsToUtc', () => {
-  it('returns an ISO formatted UTC date for valid date-time parts that fall within BST period', () => {
+  describe('valid', () => {
+    it('returns an ISO formatted UTC date for valid date-time parts that fall within BST period', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2021', month: '05', day: '30', hour: '14', minute: '12' },
+        { includeTime: true }
+      )
+      expect(result).toEqual('2021-05-30T13:12:00.000Z')
+    })
+
+    it('returns an ISO formatted UTC date for valid date parts', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2021', month: '05', day: '30' })
+      expect(result).toEqual('2021-05-30')
+    })
+
+    it('returns an ISO formatted UTC date for valid date-time parts that fall outside BST period', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2021', month: '01', day: '12', hour: '11', minute: '40' },
+        { includeTime: true }
+      )
+      expect(result).toEqual('2021-01-12T11:40:00.000Z')
+    })
+
+    it('returns an ISO formatted UTC date-time for a valid date-time', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2021', month: '01', day: '12', hour: '10', minute: '53' },
+        { includeTime: true }
+      )
+      expect(result).toEqual('2021-01-12T10:53:00.000Z')
+    })
+
+    it('returns an ISO formatted UTC date for a valid date', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2021', month: '01', day: '12' })
+      expect(result).toEqual('2021-01-12')
+    })
+
+    it('allows single-digit parts if validatePartLengths option is not passed', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2021', month: '3', day: '5', hour: '5', minute: '1' },
+        { includeTime: true }
+      )
+      expect(result).toEqual('2021-03-05T05:01:00.000Z')
+    })
+
+    it('assumes a 2 digit year of between 0 and current year, is this century, if validatePartLengths option is not true', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '21', month: '3', day: '5', hour: '5', minute: '1' },
+        { includeTime: true }
+      )
+      expect(result).toEqual('2021-03-05T05:01:00.000Z')
+    })
+
+    it('assumes a 2 digit year of greater than current year, is last century, if validatePartLengths option is not true', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '83', month: '3', day: '5', hour: '5', minute: '1' },
+        { includeTime: true }
+      )
+      expect(result).toEqual('1983-03-05T05:01:00.000Z')
+    })
+
+    it('returns an ISO formatted UTC date for a 29 Feb date in a leap year', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2020', month: '02', day: '29' })
+      expect(result).toEqual('2020-02-29')
+    })
+
+    it('returns valid date string if a date must be in the past and is today', () => {
+      const today = DateTime.now()
+      const { year, month, day } = today
+      const result = convertGmtDatePartsToUtc(
+        { year: year.toString(), month: padWithZeroes(month), day: padWithZeroes(day) },
+        { dateMustBeInPast: true, includeTime: false }
+      )
+      expect(result).toEqual(today.toISODate())
+    })
+  })
+
+  describe('error - part(s) missing', () => {
+    it('error for a date with all parts missing', () => {
+      const result = convertGmtDatePartsToUtc({ year: '', month: '', day: '' })
+      expect(result).toEqual({ errorId: 'blankDateTime' })
+    })
+
+    it('error for a date-time with all parts missing', () => {
+      const result = convertGmtDatePartsToUtc({ year: '', month: '', day: '', hour: '', minute: '' })
+      expect(result).toEqual({ errorId: 'blankDateTime' })
+    })
+
+    it('error for a date with any part missing', () => {
+      const result = convertGmtDatePartsToUtc({ year: '', month: '3', day: '20' })
+      expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['year'] })
+    })
+
+    it('error for a date-time with parts missing from date and time', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '', month: '03', day: '20', hour: '', minute: '05' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['year', 'hour'] })
+    })
+
+    it('error for a date with any parts missing', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2021', month: '', day: '' })
+      expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['day', 'month'] })
+    })
+
+    it('error for a date-time with all date parts missing', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '', month: '', day: '', hour: '03', minute: '04' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({ errorId: 'missingDate' })
+    })
+
+    it('error for a date-time with any time parts missing', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2021', month: '03', day: '25', hour: '05', minute: '' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['minute'] })
+    })
+
+    it('error for a date-time with all time parts missing', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2021', month: '03', day: '25', hour: '', minute: '' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({ errorId: 'missingTime' })
+    })
+  })
+
+  describe('error - value(s) not in valid range', () => {
+    it('error for a date with any part over the max allowed value', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2020', month: '32', day: '45' })
+      expect(result).toEqual({
+        errorId: 'outOfRangeValueDateParts',
+        invalidParts: ['day', 'month'],
+      })
+    })
+
+    it('error for a date with the year below the minimum value', () => {
+      const result = convertGmtDatePartsToUtc({ year: '1899', month: '10', day: '12' })
+      expect(result).toEqual({ errorId: 'minValueDateYear' })
+    })
+
+    it('error for a date with any date part having a negative value', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2020', month: '-5', day: '12' })
+      expect(result).toEqual({
+        errorId: 'outOfRangeValueDateParts',
+        invalidParts: ['month'],
+      })
+    })
+
+    it('error for a date-time with any hour part having a negative value', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2020', month: '05', day: '12', hour: '-10', minute: '53' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({
+        errorId: 'outOfRangeValueDateParts',
+        invalidParts: ['hour'],
+      })
+    })
+
+    it('error for a date-time with any hour part over the max allowed value', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2020', month: '05', day: '12', hour: '24', minute: '53' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({
+        errorId: 'outOfRangeValueDateParts',
+        invalidParts: ['hour'],
+      })
+    })
+
+    it('error for a date-time with any minute part having a negative value', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2020', month: '05', day: '12', hour: '10', minute: '-10' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({
+        errorId: 'outOfRangeValueDateParts',
+        invalidParts: ['minute'],
+      })
+    })
+
+    it('error for a date-time with any minute part having a value out of bounds', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2020', month: '05', day: '12', hour: '23', minute: '60' },
+        { includeTime: true }
+      )
+      expect(result).toEqual({
+        errorId: 'outOfRangeValueDateParts',
+        invalidParts: ['minute'],
+      })
+    })
+
+    it('error for a 29 Feb date not in a leap year', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2021', month: '02', day: '29' })
+      expect(result).toEqual({ errorId: 'invalidDate' })
+    })
+  })
+
+  describe('error - future date', () => {
+    it('error if a date-time must be in the past but is in the future', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2050', month: '12', day: '10', hour: '23', minute: '12' },
+        { dateMustBeInPast: true, includeTime: true }
+      )
+      expect(result).toEqual({ errorId: 'dateMustBeInPast' })
+    })
+
+    it('error if a date must be in the past but is in the future', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2045', month: '03', day: '04' },
+        { dateMustBeInPast: true, includeTime: false }
+      )
+      expect(result).toEqual({ errorId: 'dateMustBeInPast' })
+    })
+
+    it('error if a date-time must be in the future but is in the past', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2020', month: '12', day: '10', hour: '23', minute: '12' },
+        { dateMustBeInFuture: true, includeTime: true }
+      )
+      expect(result).toEqual({ errorId: 'dateMustBeInFuture' })
+    })
+
+    it('error if a date must be in the future but is in the past', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '2020', month: '03', day: '04' },
+        { dateMustBeInFuture: true, includeTime: false }
+      )
+      expect(result).toEqual({ errorId: 'dateMustBeInFuture' })
+    })
+  })
+
+  describe('error - part(s) not minimum length', () => {
+    it('error for a date-time with any single-digit parts not padded with zeroes, if validatePartLengths option is passed', () => {
+      const result = convertGmtDatePartsToUtc(
+        { year: '21', month: '3', day: '5', hour: '5', minute: '1' },
+        { includeTime: true, validatePartLengths: true }
+      )
+      expect(result).toEqual({
+        errorId: 'minLengthDateTimeParts',
+        invalidParts: ['day', 'month', 'year', 'hour', 'minute'],
+      })
+    })
+
+    it('error for a date with any single-digit parts not padded with zeroes, if validatePartLengths option is passed', () => {
+      const result = convertGmtDatePartsToUtc({ year: '2021', month: '3', day: '5' }, { validatePartLengths: true })
+      expect(result).toEqual({ errorId: 'minLengthDateParts', invalidParts: ['day', 'month'] })
+    })
+
+    it('error for a year of less than 4 digits, if validatePartLengths option is passed', () => {
+      const result = convertGmtDatePartsToUtc({ year: '21', month: '03', day: '05' }, { validatePartLengths: true })
+      expect(result).toEqual({ errorId: 'minLengthDateParts', invalidParts: ['year'] })
+    })
+  })
+
+  it('error for a date-time with any part not being an integer', () => {
     const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '05', day: '30', hour: '14', minute: '12' },
-      { includeTime: true }
-    )
-    expect(result).toEqual('2021-05-30T13:12:00.000Z')
-  })
-
-  it('returns an ISO formatted UTC date for valid date parts', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2021', month: '05', day: '30' })
-    expect(result).toEqual('2021-05-30')
-  })
-
-  it('returns an ISO formatted UTC date for valid date-time parts that fall outside BST period', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '01', day: '12', hour: '11', minute: '40' },
-      { includeTime: true }
-    )
-    expect(result).toEqual('2021-01-12T11:40:00.000Z')
-  })
-
-  it('returns an ISO formatted UTC date-time for a valid date-time', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '01', day: '12', hour: '10', minute: '53' },
-      { includeTime: true }
-    )
-    expect(result).toEqual('2021-01-12T10:53:00.000Z')
-  })
-
-  it('returns an ISO formatted UTC date for a valid date', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2021', month: '01', day: '12' })
-    expect(result).toEqual('2021-01-12')
-  })
-
-  it('returns an error for a date with all parts missing', () => {
-    const result = convertGmtDatePartsToUtc({ year: '', month: '', day: '' })
-    expect(result).toEqual({ errorId: 'blankDateTime' })
-  })
-
-  it('returns an error for a date-time with all parts missing', () => {
-    const result = convertGmtDatePartsToUtc({ year: '', month: '', day: '', hour: '', minute: '' })
-    expect(result).toEqual({ errorId: 'blankDateTime' })
-  })
-
-  it('returns an error for a date with any part missing', () => {
-    const result = convertGmtDatePartsToUtc({ year: '', month: '3', day: '20' })
-    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['year'] })
-  })
-
-  it('returns an error for a date-time with any part not being an integer', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: 'ff21', month: '3.2', day: '-0.5', hour: 'ab1', minute: '-100' },
+      { year: 'ff21', month: '3.2', day: '1.5', hour: 'ab1', minute: '35.3' },
       { includeTime: true }
     )
     expect(result).toEqual({ errorId: 'invalidDate' })
-  })
-
-  it('returns an error for a date with any part over the max allowed value', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2020', month: '32', day: '45' })
-    expect(result).toEqual({ errorId: 'invalidDate' })
-  })
-
-  it('returns an error for a date with the year below the minimum value', () => {
-    const result = convertGmtDatePartsToUtc({ year: '1899', month: '10', day: '12' })
-    expect(result).toEqual({ errorId: 'minValueDateYear' })
-  })
-
-  it('returns undefined for a 29 Feb date not in a leap year', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2021', month: '02', day: '29' })
-    expect(result).toEqual({ errorId: 'invalidDate' })
-  })
-
-  it('returns an ISO formatted UTC date for a 29 Feb date in a leap year', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2020', month: '02', day: '29' })
-    expect(result).toEqual('2020-02-29')
-  })
-
-  it('returns an error for a date with any date part having a negative value', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2020', month: '-5', day: '12' })
-    expect(result).toEqual({ errorId: 'invalidDate' })
-  })
-
-  it('returns an error for a date-time with any hour part having a negative value', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2020', month: '05', day: '12', hour: '-10', minute: '53' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'invalidTime' })
-  })
-
-  it('returns an error for a date-time with any hour part over the max allowed value', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2020', month: '05', day: '12', hour: '24', minute: '53' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'invalidTime' })
-  })
-
-  it('returns an error for a date-time with any minute part having a negative value', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2020', month: '05', day: '12', hour: '-10', minute: '53' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'invalidTime' })
-  })
-
-  it('returns an error for a date-time with any minute part having a value out of bounds', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2020', month: '05', day: '12', hour: '23', minute: '60' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'invalidTime' })
-  })
-
-  it('returns an error for a date-time with parts missing from date and time', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '', month: '03', day: '20', hour: '', minute: '05' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['year', 'hour'] })
-  })
-
-  it('returns an error for a date with any parts missing', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2021', month: '', day: '' })
-    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['day', 'month'] })
-  })
-
-  it('returns an error for a date-time with all date parts missing', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '', month: '', day: '', hour: '03', minute: '04' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'missingDate' })
-  })
-
-  it('returns an error for a date-time with any time parts missing', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '03', day: '25', hour: '05', minute: '' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'missingDateParts', invalidParts: ['minute'] })
-  })
-
-  it('returns an error for a date-time with all time parts missing', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '03', day: '25', hour: '', minute: '' },
-      { includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'missingTime' })
-  })
-
-  it('returns an error if a date-time must be in the past but is in the future', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2050', month: '12', day: '10', hour: '23', minute: '12' },
-      { dateMustBeInPast: true, includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'dateMustBeInPast' })
-  })
-
-  it('returns an error if a date must be in the past but is in the future', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2045', month: '03', day: '04' },
-      { dateMustBeInPast: true, includeTime: false }
-    )
-    expect(result).toEqual({ errorId: 'dateMustBeInPast' })
-  })
-
-  it('returns valid date string if a date must be in the past and is today', () => {
-    const today = DateTime.now()
-    const { year, month, day } = today
-    const result = convertGmtDatePartsToUtc(
-      { year: year.toString(), month: padWithZeroes(month), day: padWithZeroes(day) },
-      { dateMustBeInPast: true, includeTime: false }
-    )
-    expect(result).toEqual(today.toISODate())
-  })
-
-  it('returns an error if a date-time must be in the future but is in the past', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2020', month: '12', day: '10', hour: '23', minute: '12' },
-      { dateMustBeInFuture: true, includeTime: true }
-    )
-    expect(result).toEqual({ errorId: 'dateMustBeInFuture' })
-  })
-
-  it('returns an error if a date must be in the future but is in the past', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2020', month: '03', day: '04' },
-      { dateMustBeInFuture: true, includeTime: false }
-    )
-    expect(result).toEqual({ errorId: 'dateMustBeInFuture' })
-  })
-
-  it('allows single-digit parts if validatePartLengths option is not passed', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '3', day: '5', hour: '5', minute: '1' },
-      { includeTime: true }
-    )
-    expect(result).toEqual('2021-03-05T05:01:00.000Z')
-  })
-
-  it('returns an error for a date-time with any single-digit parts not padded with zeroes, if validatePartLengths option is passed', () => {
-    const result = convertGmtDatePartsToUtc(
-      { year: '2021', month: '3', day: '5', hour: '5', minute: '1' },
-      { includeTime: true, validatePartLengths: true }
-    )
-    expect(result).toEqual({ errorId: 'minLengthDateTimeParts', invalidParts: ['day', 'month', 'hour', 'minute'] })
-  })
-
-  it('returns an error for a date with any single-digit parts not padded with zeroes, if validatePartLengths option is passed', () => {
-    const result = convertGmtDatePartsToUtc({ year: '2021', month: '3', day: '5' }, { validatePartLengths: true })
-    expect(result).toEqual({ errorId: 'minLengthDateParts', invalidParts: ['day', 'month'] })
-  })
-
-  it('returns an error for a year of less than 4 digits, if validatePartLengths option is passed', () => {
-    const result = convertGmtDatePartsToUtc({ year: '21', month: '03', day: '05' }, { validatePartLengths: true })
-    expect(result).toEqual({ errorId: 'minLengthDateParts', invalidParts: ['year'] })
   })
 })
 

--- a/server/utils/errors.test.ts
+++ b/server/utils/errors.test.ts
@@ -119,5 +119,13 @@ describe('Error messages', () => {
       const error = formatValidationErrorMessage({ errorId: 'minValueDateYear' }, 'date of sentence')
       expect(error).toEqual('The date of sentence must include a year after 1900')
     })
+
+    it('renders "outOfRangeValueDateParts" error', () => {
+      const error = formatValidationErrorMessage(
+        { errorId: 'outOfRangeValueDateParts', invalidParts: ['year'] },
+        'date of sentence'
+      )
+      expect(error).toEqual('The date of sentence must have a valid value for year')
+    })
   })
 })

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -50,6 +50,8 @@ export const formatValidationErrorMessage = (validationError: ValidationError, f
       return `The ${fieldLabel} must include a time`
     case 'missingDateParts':
       return `The ${fieldLabel} must include a ${listToString(validationError.invalidParts, 'and')}`
+    case 'outOfRangeValueDateParts':
+      return `The ${fieldLabel} must have a valid value for ${listToString(validationError.invalidParts, 'and')}`
     case 'minLengthDateTimeParts':
       return `The ${fieldLabel} must be in the correct format, like 06 05 2021 09:03`
     case 'minValueDateYear':
@@ -61,4 +63,9 @@ export const formatValidationErrorMessage = (validationError: ValidationError, f
     default:
       return `Error - ${fieldLabel}`
   }
+}
+
+export const invalidDateInputPart = (validationError: ValidationError, fieldLabel?: string): string => {
+  const part = validationError.invalidParts?.length ? validationError.invalidParts[0] : 'day'
+  return `${fieldLabel}-${part}`
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,7 +2,7 @@
 import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
-import { formatSingleLineAddress, makePageTitle, errorMessage } from './utils'
+import { formatSingleLineAddress, makePageTitle, errorMessage, countLabel } from './utils'
 import config from '../config'
 import { formatDateTimeFromIsoString } from './dates/format'
 import { dateTimeItems } from './nunjucks'
@@ -56,4 +56,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('errorMessage', errorMessage)
   njkEnv.addGlobal('formatSingleLineAddress', formatSingleLineAddress)
   njkEnv.addGlobal('dateTimeItems', dateTimeItems)
+  njkEnv.addGlobal('countLabel', countLabel)
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -87,3 +87,6 @@ export const dedupeList = <T>(list: T[]) => {
   })
   return unique
 }
+
+export const countLabel = ({ count, noun }: { count: number; noun: string }) =>
+  `${count} ${noun}${count !== 1 ? 's' : ''}`

--- a/server/views/partials/caseLicenceHistory.njk
+++ b/server/views/partials/caseLicenceHistory.njk
@@ -1,4 +1,3 @@
-
 <h1 class='govuk-heading-m'>Licence history</h1>
 <div class="govuk-grid-row">
     {% if flags.dateFilters %}
@@ -31,7 +30,6 @@
         {% endset -%}
         <div class='govuk-!-margin-bottom-4'>
         <form>
-            <input type='hidden' name='dateFilters' value='1' />
             {{ mojFilter({
                 heading: {
                     text: 'Filter'
@@ -42,14 +40,14 @@
                     },
                     clearLink: {
                         text: 'Clear filters',
-                        href: urlInfo.path + '?dateFilters=1'
+                        href: urlInfo.path
                     },
                     categories: [{
                         heading: {
                             text: 'Date range'
                         },
                         items: [{
-                            href: urlInfo.path + '?dateFilters=1',
+                            href: urlInfo.path,
                             text: caseSummary.filters.dateRange.selectedLabel
                         }]
                     }]
@@ -62,9 +60,9 @@
     {% endif %}
     <div class="govuk-grid-column-two-thirds-from-desktop">
         {% set innerLoopIndex = 0 %}
-        <div class='govuk-body govuk-!-margin-bottom-4 govuk-!-font-weight-bold'>{{ caseSummary.contactCount }}
-            contacts
-        </div>
+        <h2 class='govuk-body govuk-!-margin-bottom-4 govuk-!-font-weight-bold'>
+            {{ countLabel({ count: caseSummary.contactCount, noun: 'contact'}) }}
+        </h2>
         <div class="filter-toggle"></div>
         {% for group in caseSummary.contactSummary.items %}
             <div class='govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-2' data-qa='date-{{ loop.index0 }}'>


### PR DESCRIPTION
- prefix page title with number of contact results, for screen readers
- set result count as an H2, for easier location by screen readers
- more specific date validation - indicate which part of the date is invalid, and link to that input from the error summary
- add date filter URLs to the accessibility tests