### PR TITLE
MRD-148 and MRD-117 - quick fixes

### DIFF
--- a/e2e_tests/integration/caseSummary.feature
+++ b/e2e_tests/integration/caseSummary.feature
@@ -9,3 +9,4 @@ Feature: Case summary
     And Maria views the risk page
     And Maria views the personal details page
     And Maria views the licence history page
+    And Maria filters contacts by date range

--- a/e2e_tests/integration/stepDefinitions/index.ts
+++ b/e2e_tests/integration/stepDefinitions/index.ts
@@ -34,3 +34,15 @@ When('Maria views the licence history page', () => {
   cy.clickLink('Licence history')
   cy.pageHeading().should('equal', 'Licence history')
 })
+
+When('Maria filters contacts by date range', () => {
+  cy.get('.app-summary-card')
+    .its('length')
+    .then(numberOfContacts => {
+      cy.getElement(`${numberOfContacts} contacts`).should('exist')
+    })
+  cy.enterDateTime('2022-03-13', { parent: '#dateFrom' })
+  cy.enterDateTime('2022-04-13', { parent: '#dateTo' })
+  cy.clickButton('Apply filters')
+  cy.getLinkHref('13-03-2022 to 13-04-2022').should('equal', `/cases/${crn}/licence-history`)
+})

--- a/integration_tests/integration/caseSummary.spec.ts
+++ b/integration_tests/integration/caseSummary.spec.ts
@@ -63,7 +63,10 @@ context('Case summary', () => {
       formatDateTimeFromIsoString({ isoDate: personalDetailsOverview.gender })
     )
     // personal details
-    cy.getDefinitionListValue('Current address').should('equal', '5 Anderton Road, Newham, London E15 1UJ')
+    cy.getDefinitionListValue('Current address').should('contain', '5 Anderton Road')
+    cy.getDefinitionListValue('Current address').should('contain', 'Newham')
+    cy.getDefinitionListValue('Current address').should('contain', 'London')
+    cy.getDefinitionListValue('Current address').should('contain', 'E15 1UJ')
     cy.getDefinitionListValue('Probation practitioner').should('contain', 'Jenny Eclair - N07, NPS London')
     cy.getDefinitionListValue('Probation practitioner').should('contain', 'Telephone: 07824637629')
     cy.getDefinitionListValue('Probation practitioner').should('contain', 'Email: jenny@probation.com')

--- a/server/views/partials/caseLicenceHistory.njk
+++ b/server/views/partials/caseLicenceHistory.njk
@@ -65,9 +65,9 @@
         </h2>
         <div class="filter-toggle"></div>
         {% for group in caseSummary.contactSummary.items %}
-            <div class='govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-2' data-qa='date-{{ loop.index0 }}'>
+            <h3 class='govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-2' data-qa='date-{{ loop.index0 }}'>
                 {{ formatDateTimeFromIsoString({ isoDate: group.groupValue, dateOnly: true}) }}
-            </div>
+            </h3>
             {% for contact in group.items %}
                 {% set titleHtml %}
                     <div>
@@ -114,6 +114,7 @@
                 <div data-qa='contact-{{ innerLoopIndex }}'>
                     {{ appSummaryCard({
                         titleHtml: titleHtml,
+                        headingLevel: 4,
                         classes: 'govuk-!-margin-bottom-3',
                         html: sectionHtml if contact.notes else undefined,
                         actionsHtml: actionsHtml

--- a/server/views/partials/casePersonalDetails.njk
+++ b/server/views/partials/casePersonalDetails.njk
@@ -6,6 +6,12 @@
             {% if caseSummary.offenderManager.phoneNumber %}<div>Telephone: {{ caseSummary.offenderManager.phoneNumber }}</div>{% endif %}
             {% if caseSummary.offenderManager.email %}<div>Email: <a href='mailto:{{ caseSummary.offenderManager.email }}' target='_blank' rel='noopener' data-qa='offenderManagerEmail'>{{ caseSummary.offenderManager.email }}</a></div>{% endif %}
         {% endset %}
+        {% set addressHtml %}
+            {% if caseSummary.currentAddress.line1 %}<div>{{ caseSummary.currentAddress.line1 }}</div>{% endif %}
+            {% if caseSummary.currentAddress.line2 %}<div>{{ caseSummary.currentAddress.line2 }}</div>{% endif %}
+            {% if caseSummary.currentAddress.town %}<div>{{ caseSummary.currentAddress.town }}</div>{% endif %}
+            {% if caseSummary.currentAddress.postcode %}<div>{{ caseSummary.currentAddress.postcode }}</div>{% endif %}
+        {% endset %}
         {{ appSummaryCard({
             titleText: 'Personal details',
             classes: 'govuk-!-margin-bottom-6 app-summary-card--large-title',
@@ -13,7 +19,7 @@
                 rows: [
                     {
                         key: { html: 'Current address' },
-                        value: { text: formatSingleLineAddress(caseSummary.currentAddress) }
+                        value: { html: addressHtml }
                     },
                     {
                         key: { text: 'Probation practitioner' },


### PR DESCRIPTION
MRD-148 - Licence history - hierarchical headings for results list, for screen readers. Extend E2E test to cover date filter
MRD-117 - personal details - render address parts on separate lines