### PR TITLE
Allow deploys even with failing preprod e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,6 @@ workflows:
       not:
         or:
           - << pipeline.parameters.e2e-check-dev >>
-          - << pipeline.parameters.e2e-check-preprod >>
     jobs:
       - build:
           filters:


### PR DESCRIPTION
Temporary workaround for preprod env being unavailable due to data refresh