### PR TITLE
MRD-205 - Fix bug where all terms had to match in the same contact field

### DIFF
--- a/integration_tests/integration/contactHistory.spec.ts
+++ b/integration_tests/integration/contactHistory.spec.ts
@@ -129,13 +129,13 @@ context('Contact history', () => {
     cy.getElement('3 contacts').should('exist')
     // one of the 3 contacts was matched on notes, so check the notes were expanded
     cy.isDetailsOpen('View more detail', { parent: '[data-qa="contact-1"]' }).should('equal', true)
-    cy.fillInput('Search term', 'Licence compliance')
+    cy.fillInput('Search term', 'Eliot Prufrock')
     cy.clickButton('Apply filters')
-    cy.getElement('2 contacts').should('exist')
-    // clear filters
-    cy.clickLink('Licence compliance')
     cy.getElement('3 contacts').should('exist')
+    // clear filters
     cy.clickLink('letter')
+    cy.getElement('8 contacts').should('exist')
+    cy.clickLink('Eliot Prufrock')
     cy.getElement('12 contacts').should('exist')
   })
 

--- a/server/controllers/caseSummary/contactHistory/filterContactsBySearch.test.ts
+++ b/server/controllers/caseSummary/contactHistory/filterContactsBySearch.test.ts
@@ -70,10 +70,8 @@ describe('filterContactsBySearch', () => {
         enforcementAction: 'Second Enforcement Letter Sent',
         systemGenerated: false,
         searchTextMatch: {
-          description: true,
-          enforcementAction: false,
-          notes: false,
-          outcome: false,
+          allTermsMatched: true,
+          notesMatched: false,
         },
         startDate: null,
       },
@@ -99,10 +97,8 @@ describe('filterContactsBySearch', () => {
         enforcementAction: 'Second Enforcement Letter Sent',
         systemGenerated: false,
         searchTextMatch: {
-          description: true,
-          enforcementAction: false,
-          notes: false,
-          outcome: false,
+          allTermsMatched: true,
+          notesMatched: false,
         },
         startDate: null,
       },
@@ -129,10 +125,8 @@ describe('filterContactsBySearch', () => {
         enforcementAction: null,
         systemGenerated: false,
         searchTextMatch: {
-          description: false,
-          enforcementAction: false,
-          notes: true,
-          outcome: false,
+          allTermsMatched: true,
+          notesMatched: true,
         },
         startDate: null,
       },
@@ -158,10 +152,8 @@ describe('filterContactsBySearch', () => {
         enforcementAction: 'Decision Pending Response from Person on Probation',
         systemGenerated: false,
         searchTextMatch: {
-          description: false,
-          enforcementAction: false,
-          notes: false,
-          outcome: true,
+          allTermsMatched: true,
+          notesMatched: false,
         },
         startDate: null,
       },
@@ -174,10 +166,8 @@ describe('filterContactsBySearch', () => {
         enforcementAction: 'Second Enforcement Letter Sent',
         systemGenerated: false,
         searchTextMatch: {
-          description: false,
-          enforcementAction: false,
-          notes: false,
-          outcome: true,
+          allTermsMatched: true,
+          notesMatched: false,
         },
         startDate: null,
       },
@@ -203,10 +193,8 @@ describe('filterContactsBySearch', () => {
         enforcementAction: 'Second Enforcement Letter Sent',
         systemGenerated: false,
         searchTextMatch: {
-          description: false,
-          enforcementAction: true,
-          notes: false,
-          outcome: false,
+          allTermsMatched: true,
+          notesMatched: false,
         },
         startDate: null,
       },
@@ -232,5 +220,72 @@ describe('filterContactsBySearch', () => {
       },
     ])
     expect(selected).toBeUndefined()
+  })
+
+  it('matches a contact if all search filters match against different fields', () => {
+    const { contacts, selected } = filterContactsBySearch({
+      contacts: [
+        {
+          code: 'ROC',
+          descriptionType: 'Responsible Officer Change',
+          contactStartDate: '2022-04-21T11:30:00Z',
+          outcome: 'Failed to Attend',
+          notes:
+            'Comment added by Eliot Prufrock on 20/04/2022 at 11:35\nEnforcement Action: Refer to Offender Manager',
+          enforcementAction: 'Decision Pending Response from Person on Probation',
+          systemGenerated: false,
+        },
+      ],
+      filters: {
+        ...defaultFilters,
+        searchFilters: ['Responsible officer', 'Prufrock'],
+      },
+    })
+    expect(contacts).toEqual([
+      {
+        code: 'ROC',
+        descriptionType: 'Responsible Officer Change',
+        contactStartDate: '2022-04-21T11:30:00Z',
+        outcome: 'Failed to Attend',
+        notes: 'Comment added by Eliot Prufrock on 20/04/2022 at 11:35\nEnforcement Action: Refer to Offender Manager',
+        enforcementAction: 'Decision Pending Response from Person on Probation',
+        systemGenerated: false,
+        searchTextMatch: {
+          allTermsMatched: true,
+          notesMatched: true,
+        },
+        startDate: null,
+      },
+    ])
+    expect(selected).toEqual([
+      { text: 'Responsible officer', href: '?searchFilters=Prufrock' },
+      { text: 'Prufrock', href: '?searchFilters=Responsible%20officer' },
+    ])
+  })
+
+  it('does not match a contact if not all search filters match against different fields', () => {
+    const { contacts, selected } = filterContactsBySearch({
+      contacts: [
+        {
+          code: 'ROC',
+          descriptionType: 'Responsible Officer Change',
+          contactStartDate: '2022-04-21T11:30:00Z',
+          outcome: 'Failed to Attend',
+          notes:
+            'Comment added by Eliot Prufrock on 20/04/2022 at 11:35\nEnforcement Action: Refer to Offender Manager',
+          enforcementAction: 'Decision Pending Response from Person on Probation',
+          systemGenerated: false,
+        },
+      ],
+      filters: {
+        ...defaultFilters,
+        searchFilters: ['Responsible officer', 'Derby'],
+      },
+    })
+    expect(contacts).toEqual([])
+    expect(selected).toEqual([
+      { text: 'Responsible officer', href: '?searchFilters=Derby' },
+      { text: 'Derby', href: '?searchFilters=Responsible%20officer' },
+    ])
   })
 })

--- a/server/controllers/caseSummary/contactHistory/transformContactHistory.test.ts
+++ b/server/controllers/caseSummary/contactHistory/transformContactHistory.test.ts
@@ -103,10 +103,8 @@ describe('transformContactHistory', () => {
               startDate: '2022-04-21',
               systemGenerated: false,
               searchTextMatch: {
-                description: true,
-                enforcementAction: false,
-                notes: false,
-                outcome: false,
+                allTermsMatched: true,
+                notesMatched: false,
               },
             },
           ],

--- a/server/views/partials/caseContactHistory.njk
+++ b/server/views/partials/caseContactHistory.njk
@@ -48,7 +48,7 @@
                     {{ govukDetails({
                         summaryText: "View more detail",
                         html: notesHtml,
-                        open: contact.searchTextMatch.notes
+                        open: contact.searchTextMatch.notesMatched
                     }) }}
                 {% endset %}
                 <div data-qa='contact-{{ innerLoopIndex }}'>


### PR DESCRIPTION
The bug was: when multiple search terms were specified, for at least one of the contact fields (description, notes, outcome, enforcement action), **all** search terms had to match against that field

The new behaviour is: as long as each of the search terms has a match in at least one of the fields, then the contact is included in results.