### PR TITLE
MRD-294 - Ignore 'non-error exceptions'

### DIFF
--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -12,7 +12,7 @@ export default function setUpSentry(): Router {
       // enable Express.js middleware tracing
       new Tracing.Integrations.Express({ app: router }),
     ],
-    ignoreErrors: ['AbortError', /^Invalid URL$/, /^Redis connection to/],
+    ignoreErrors: ['AbortError', /^Invalid URL$/, /^Redis connection to/, 'Non-Error exception captured'],
     // Quarter of all requests will be used for performance sampling
     tracesSampler: samplingContext => {
       const transactionName =


### PR DESCRIPTION
This was causing every API error to cause a secondary error because Sentry was being passed a non-error instance