### PR TITLE
MRD-546 - Restore universal GA IDs (dual connect)

### DIFF
--- a/server/middleware/setAnalyticsId.ts
+++ b/server/middleware/setAnalyticsId.ts
@@ -4,10 +4,10 @@ export const setAnalyticsId = (req: Request, res: Response, next: NextFunction) 
   // dummy ID for testing locally / automated tests
   res.locals.googleAnalyticsId = 'UA-123456789-00'
   if (res.locals.env === 'PRODUCTION' && res.locals.flags.flagExcludeFromAnalytics !== true) {
-    res.locals.googleAnalyticsId = 'G-JD5W689LSX'
+    res.locals.googleAnalyticsId = 'UA-106741063-23'
   }
   if (res.locals.env === 'PRE-PRODUCTION') {
-    res.locals.googleAnalyticsId = 'G-4NZ883ZE66'
+    res.locals.googleAnalyticsId = 'UA-106741063-22'
   }
   next()
 }


### PR DESCRIPTION
Data will be sent to both universal and GA4 accounts