### PR TITLE
Speed up Jest unit tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-NODE_ENV=dev && node_modules/.bin/lint-staged && node_modules/.bin/tsc && npm test
+NODE_ENV=dev && node_modules/.bin/lint-staged && npm run typecheck && npm test

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "lint:fix": "eslint . --cache --max-warnings 0 --fix",
     "swagger-to-ts": "node ./scripts/swagger-to-ts.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p integration_tests && tsc --noEmit -p e2e_tests",
-    "test": "jest --forceExit --runInBand",
-    "test:coverage": "jest --coverage",
+    "test": "jest --forceExit",
+    "test:coverage": "jest --coverage --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --browser chrome --config-file integration_tests/cypress.json",
     "int-test-ui": "cypress open --config-file integration_tests/cypress.json",
@@ -41,6 +41,11 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "globals": {
+      "ts-jest": {
+        "isolatedModules": true
+      }
+    },
     "collectCoverageFrom": [
       "server/**/*.{ts,js,jsx,mjs}"
     ],


### PR DESCRIPTION
From a change to the template - https://github.com/ministryofjustice/hmpps-template-typescript/pull/116

400 unit tests now run in ~9s, down from 25s