### PR TITLE
MRD-691 - Show emergency recall page after fixed term recall

### DIFF
--- a/e2e_tests/integration/recallDeterminate.feature
+++ b/e2e_tests/integration/recallDeterminate.feature
@@ -14,6 +14,7 @@ Feature: Recall (determinate)
     And Maria confirms "No" for indeterminate sentence
     And Maria confirms "No" for extended sentence
     And Maria recommends a "Fixed term" recall
+    And Maria confirms "No" for emergency recall
     And Maria adds licence conditions for the fixed term recall
     And Maria reads the guidance on sensitive information
     And Maria confirms the person is in prison custody

--- a/server/controllers/recommendations/emergencyRecall/formValidator.test.ts
+++ b/server/controllers/recommendations/emergencyRecall/formValidator.test.ts
@@ -11,6 +11,7 @@ describe('validateEmergencyRecall', () => {
   it('returns valuesToSave and no errors if valid', async () => {
     const requestBody = {
       isThisAnEmergencyRecall: 'YES',
+      recallType: 'STANDARD',
       crn: 'X34534',
     }
     const { errors, valuesToSave, nextPagePath } = await validateEmergencyRecall({ requestBody, urlInfo })
@@ -19,6 +20,20 @@ describe('validateEmergencyRecall', () => {
       isThisAnEmergencyRecall: true,
     })
     expect(nextPagePath).toEqual('/recommendations/34/sensitive-info')
+  })
+
+  it("redirects to fixed term licence conditions if it's a fixed term recall", async () => {
+    const requestBody = {
+      isThisAnEmergencyRecall: 'YES',
+      recallType: 'FIXED_TERM',
+      crn: 'X34534',
+    }
+    const { errors, valuesToSave, nextPagePath } = await validateEmergencyRecall({ requestBody, urlInfo })
+    expect(errors).toBeUndefined()
+    expect(valuesToSave).toEqual({
+      isThisAnEmergencyRecall: true,
+    })
+    expect(nextPagePath).toEqual('/recommendations/34/fixed-licence')
   })
 
   it('returns an error, if not set, and no valuesToSave', async () => {

--- a/server/controllers/recommendations/emergencyRecall/formValidator.ts
+++ b/server/controllers/recommendations/emergencyRecall/formValidator.ts
@@ -9,7 +9,7 @@ export const validateEmergencyRecall = async ({ requestBody, urlInfo }: FormVali
   let valuesToSave
   let nextPagePath
 
-  const { isThisAnEmergencyRecall } = requestBody
+  const { isThisAnEmergencyRecall, recallType } = requestBody
   if (!isThisAnEmergencyRecall || !isValueValid(isThisAnEmergencyRecall as string, 'isThisAnEmergencyRecall')) {
     const errorId = 'noEmergencyRecallSelected'
     errors = [
@@ -24,7 +24,8 @@ export const validateEmergencyRecall = async ({ requestBody, urlInfo }: FormVali
     valuesToSave = {
       isThisAnEmergencyRecall: isThisAnEmergencyRecall === 'YES',
     }
-    nextPagePath = nextPageLinkUrl({ nextPageId: 'sensitive-info', urlInfo })
+    const nextPageId = recallType === 'FIXED_TERM' ? 'fixed-licence' : 'sensitive-info'
+    nextPagePath = nextPageLinkUrl({ nextPageId, urlInfo })
   }
   return {
     errors,

--- a/server/controllers/recommendations/recallType/formValidator.test.ts
+++ b/server/controllers/recommendations/recallType/formValidator.test.ts
@@ -69,14 +69,14 @@ describe('validateRecallType', () => {
     })
 
     describe('Redirects', () => {
-      it('redirects to custody status if Fixed term recall is selected', async () => {
+      it('redirects to emergency recall if Fixed term recall is selected', async () => {
         const requestBody = {
           recallType: 'FIXED_TERM',
           recallTypeDetailsFixedTerm: 'I recommend fixed term recall...',
           crn: 'X34534',
         }
         const { nextPagePath } = await validateRecallType({ requestBody, recommendationId, urlInfo })
-        expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/fixed-licence`)
+        expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/emergency-recall`)
       })
 
       it('redirects to emergency recall if Standard recall is selected', async () => {
@@ -98,7 +98,7 @@ describe('validateRecallType', () => {
         expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/task-list-no-recall`)
       })
 
-      it('if "from page" is set to recall task list, ignore it if a fixed term recall is selected', async () => {
+      it('if "from page" is set, ignore it if a fixed term recall is selected', async () => {
         const requestBody = {
           recallType: 'FIXED_TERM',
           recallTypeDetailsFixedTerm: 'I recommend fixed term recall...',
@@ -110,10 +110,10 @@ describe('validateRecallType', () => {
           recommendationId,
           urlInfo: urlInfoWithFromPage,
         })
-        expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/fixed-licence`)
+        expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/emergency-recall`)
       })
 
-      it('if "from page" is set to recall task list, redirects to it if a standard recall is selected', async () => {
+      it('if "from page" is set, ignore it if a standard recall is selected', async () => {
         const requestBody = {
           recallType: 'STANDARD',
           recallTypeDetailsStandard: 'I recommend standard recall...',
@@ -128,7 +128,7 @@ describe('validateRecallType', () => {
         expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/emergency-recall`)
       })
 
-      it('if "from page" is set to recall task list, don\'t redirect to it if No recall is selected', async () => {
+      it('if "from page" is set, ignore it if No recall is selected', async () => {
         const requestBody = {
           recallType: 'NO_RECALL',
           crn: 'X34534',

--- a/server/controllers/recommendations/recallType/formValidator.ts
+++ b/server/controllers/recommendations/recallType/formValidator.ts
@@ -61,10 +61,7 @@ export const validateRecallType = async ({ requestBody, urlInfo }: FormValidator
     isThisAnEmergencyRecall: isFixedTerm ? false : null,
   }
   // ignore any 'from page', whatever the user selects they'll continue through the flow
-  let nextPageId = 'task-list-no-recall'
-  if (recallType !== 'NO_RECALL') {
-    nextPageId = recallType === 'FIXED_TERM' ? 'fixed-licence' : 'emergency-recall'
-  }
+  const nextPageId = recallType === 'NO_RECALL' ? 'task-list-no-recall' : 'emergency-recall'
   return {
     valuesToSave,
     nextPagePath: `${urlInfo.basePath}${nextPageId}`,

--- a/server/controllers/recommendations/recallTypeIndeterminate/formValidator.test.ts
+++ b/server/controllers/recommendations/recallTypeIndeterminate/formValidator.test.ts
@@ -57,7 +57,7 @@ describe('validateRecallTypeIndeterminate', () => {
     })
 
     describe('Redirects', () => {
-      it('if "from page" is set to recall task list, redirects to it if an emergency recall is selected', async () => {
+      it('if "from page" is set, ignore it if an emergency recall is selected', async () => {
         const requestBody = {
           recallType: 'EMERGENCY',
           crn: 'X34534',
@@ -68,10 +68,10 @@ describe('validateRecallTypeIndeterminate', () => {
           recommendationId,
           urlInfo: urlInfoWithFromPage,
         })
-        expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/task-list#heading-recommendation`)
+        expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/indeterminate-details`)
       })
 
-      it('if "from page" is set to recall task list, don\'t redirect to it if No recall is selected', async () => {
+      it('if "from page" is set, ignore it if No recall is selected', async () => {
         const requestBody = {
           recallType: 'NO_RECALL',
           crn: 'X34534',

--- a/server/controllers/recommendations/recallTypeIndeterminate/formValidator.ts
+++ b/server/controllers/recommendations/recallTypeIndeterminate/formValidator.ts
@@ -2,7 +2,6 @@ import { FormValidatorArgs, FormValidatorReturn } from '../../../@types'
 import { makeErrorObject } from '../../../utils/errors'
 import { formOptions, isValueValid } from '../helpers/formOptions'
 import { strings } from '../../../textStrings/en'
-import { nextPageLinkUrl } from '../helpers/urls'
 
 export const validateRecallTypeIndeterminate = async ({
   requestBody,

--- a/server/controllers/recommendations/recallTypeIndeterminate/formValidator.ts
+++ b/server/controllers/recommendations/recallTypeIndeterminate/formValidator.ts
@@ -44,11 +44,9 @@ export const validateRecallTypeIndeterminate = async ({
     },
     isThisAnEmergencyRecall: isNoRecall ? null : true,
   }
-  const nextPagePath = isNoRecall
-    ? `${urlInfo.basePath}task-list-no-recall`
-    : nextPageLinkUrl({ nextPageId: 'indeterminate-details', urlInfo })
+  const nextPageId = isNoRecall ? 'task-list-no-recall' : 'indeterminate-details'
   return {
     valuesToSave,
-    nextPagePath,
+    nextPagePath: `${urlInfo.basePath}${nextPageId}`,
   }
 }

--- a/server/views/pages/recommendations/emergencyRecall.njk
+++ b/server/views/pages/recommendations/emergencyRecall.njk
@@ -17,6 +17,7 @@
             <form novalidate method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 <input type="hidden" name="crn" value="{{ recommendation.crn }}" />
+                <input type="hidden" name="recallType" value="{{ recommendation.recallType.selected.value }}" />
                 <div class="govuk-caption-l">Circumstances</div>
                 {{ govukRadios({
                     idPrefix: "isThisAnEmergencyRecall",


### PR DESCRIPTION
also - fix for when user clicks on 'what you recommend' from no recall task list, and on clicking continue is wrongly returned to the no recall task list