### PR TITLE
MRD-865 - Send valid recallType values to API in allOptions array

### DIFF
--- a/server/controllers/recommendations/formOptions/formOptions.ts
+++ b/server/controllers/recommendations/formOptions/formOptions.ts
@@ -7,7 +7,7 @@ import { alternativesToRecallTried } from '../alternativesToRecallTried/formOpti
 import { isUnderIntegratedOffenderManagement } from '../integratedOffenderManagement/formOptions'
 import { vulnerabilities } from '../vulnerabilities/formOptions'
 import { indeterminateSentenceType } from '../indeterminateSentenceType/formOptions'
-import { recallTypeIndeterminate } from '../recallTypeIndeterminate/formOptions'
+import { recallTypeIndeterminate, recallTypeIndeterminateApi } from '../recallTypeIndeterminate/formOptions'
 import { indeterminateOrExtendedSentenceDetails } from '../indeterminateOrExtendedSentenceDetails/formOptions'
 import { whyConsideredRecall } from '../whyConsideredRecall/formOptions'
 import { howWillAppointmentHappen } from '../nextAppointment/formOptions'
@@ -17,6 +17,7 @@ import { yesNo } from './yesNo'
 export const formOptions = {
   recallType,
   recallTypeIndeterminate,
+  recallTypeIndeterminateApi,
   standardLicenceConditions,
   custodyStatus,
   alternativesToRecallTried,

--- a/server/controllers/recommendations/recallTypeIndeterminate/formOptions.ts
+++ b/server/controllers/recommendations/recallTypeIndeterminate/formOptions.ts
@@ -2,3 +2,9 @@ export const recallTypeIndeterminate = [
   { value: 'EMERGENCY', text: 'Emergency recall' },
   { value: 'NO_RECALL', text: 'No recall' },
 ]
+
+// valid values to send to MRD API for the recallType property
+export const recallTypeIndeterminateApi = [
+  { value: 'STANDARD', text: 'Standard recall' },
+  { value: 'NO_RECALL', text: 'No recall' },
+]

--- a/server/controllers/recommendations/recallTypeIndeterminate/formValidator.test.ts
+++ b/server/controllers/recommendations/recallTypeIndeterminate/formValidator.test.ts
@@ -26,7 +26,7 @@ describe('validateRecallTypeIndeterminate', () => {
           selected: {
             value: 'NO_RECALL',
           },
-          allOptions: formOptions.recallTypeIndeterminate,
+          allOptions: formOptions.recallTypeIndeterminateApi,
         },
         isThisAnEmergencyRecall: null,
       })
@@ -49,7 +49,7 @@ describe('validateRecallTypeIndeterminate', () => {
           selected: {
             value: 'STANDARD',
           },
-          allOptions: formOptions.recallTypeIndeterminate,
+          allOptions: formOptions.recallTypeIndeterminateApi,
         },
         isThisAnEmergencyRecall: true,
       })

--- a/server/controllers/recommendations/recallTypeIndeterminate/formValidator.ts
+++ b/server/controllers/recommendations/recallTypeIndeterminate/formValidator.ts
@@ -39,7 +39,7 @@ export const validateRecallTypeIndeterminate = async ({
       selected: {
         value: isNoRecall ? recallType : 'STANDARD',
       },
-      allOptions: formOptions.recallTypeIndeterminate,
+      allOptions: formOptions.recallTypeIndeterminateApi,
     },
     isThisAnEmergencyRecall: isNoRecall ? null : true,
   }


### PR DESCRIPTION
send 'standard' instead of 'emergency_recall'