### PR TITLE
mrd-285_domain-events

### DIFF
--- a/scripts/start-services-for-e2e-tests-local.sh
+++ b/scripts/start-services-for-e2e-tests-local.sh
@@ -57,6 +57,7 @@ popd
 
 pushd "${API_DIR}"
 printf "\n\nBuilding/starting API components...\n\n"
+export SPRING_PROFILES_ACTIVE=dev
 docker-compose up -d --scale=${API_NAME}=0
 ./gradlew --stop
 SYSTEM_CLIENT_ID=make-recall-decision-api SYSTEM_CLIENT_SECRET=clientsecret HMPPS_AUTH_URL=http://localhost:9090/auth OFFENDER_SEARCH_ENDPOINT_URL=http://localhost:9080 CVL_API_ENDPOINT_URL=http://localhost:9070 COMMUNITY_API_ENDPOINT_URL=http://localhost:9081 ARN_API_ENDPOINT_URL=http://localhost:9071 GOTENBERG_ENDPOINT_URL=http://localhost:9091 POSTGRES_HOST=localhost:5432 POSTGRES_DBNAME=make_recall_decision POSTGRES_USERNAME=mrd_user POSTGRES_PASSWORD=secret SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -61,6 +61,7 @@ fi
 
 pushd "${API_DIR}"
 printf "\n\nBuilding/starting API components...\n\n"
+export SPRING_PROFILES_ACTIVE=dev
 docker-compose build
 docker-compose up -d
 popd


### PR DESCRIPTION
Set profile to dev for e2e tests to ensure API builds with AWS SNS deactivated, this preserves pipeline by removing dependency on localstack.