### PR TITLE
MRD-1004 - Separate types for contacts to their own file

### DIFF
--- a/server/@types/contactTypes.ts
+++ b/server/@types/contactTypes.ts
@@ -1,0 +1,37 @@
+import { ObjectMap } from './index'
+
+export interface ContactTypeDecorated {
+  code: string
+  count: number
+  description: string
+}
+
+export interface ContactTypeCode {
+  value: string
+  description: string
+  html: string
+  count: number
+  attributes: ObjectMap<string>
+}
+
+export interface ContactTypeGroupDecorated {
+  label: string
+  isGroupOpen: boolean
+  contactTypeCodes: ContactTypeCode[]
+}
+
+export interface ContactHistoryFilters {
+  'dateFrom-day': string
+  'dateFrom-month': string
+  'dateFrom-year': string
+  'dateTo-day': string
+  'dateTo-month': string
+  'dateTo-year': string
+  contactTypes: string | string[]
+  searchFilters: string | string[]
+}
+
+export interface SelectedFilterItem {
+  text: string
+  href: string
+}

--- a/server/@types/index.d.ts
+++ b/server/@types/index.d.ts
@@ -86,10 +86,6 @@ export interface DecoratedContact extends ContactSummaryResponse {
   }
 }
 
-export interface SelectableItem {
-  id?: number
-}
-
 export interface UiListItem {
   value: string
   text: string
@@ -107,11 +103,6 @@ export interface FormOption extends UiListItem {
   behaviour?: string
 }
 
-export interface SelectedFilterItem {
-  text: string
-  href: string
-}
-
 export interface UrlInfo {
   path: string
   fromPageId?: string
@@ -127,34 +118,6 @@ export interface FeatureFlagDefault {
 
 export type FeatureFlags = {
   [key: string]: boolean
-}
-
-export interface ContactTypeDecorated {
-  code: string
-  count: number
-  description: string
-}
-
-export interface ContactTypeGroupDecorated {
-  label: string
-  isGroupOpen: boolean
-  contactTypeCodes: {
-    value: string
-    description: string
-    html: string
-    count: number
-  }[]
-}
-
-export interface ContactHistoryFilters {
-  'dateFrom-day': string
-  'dateFrom-month': string
-  'dateFrom-year': string
-  'dateTo-day': string
-  'dateTo-month': string
-  'dateTo-year': string
-  contactTypes: string | string[]
-  searchFilters: string | string[]
 }
 
 export type PageId =

--- a/server/controllers/caseSummary/caseSummary.test.ts
+++ b/server/controllers/caseSummary/caseSummary.test.ts
@@ -124,7 +124,7 @@ describe('caseSummary', () => {
     jest.spyOn(redisExports, 'getRedisAsync').mockResolvedValue(null)
     const req = mockReq({ params: { crn, sectionId: 'contact-history' } })
     await caseSummary(req, res)
-    expect(getCaseSummary).toHaveBeenCalledWith(crn.trim(), 'contact-history', token)
+    expect(getCaseSummary).toHaveBeenCalledWith(crn.trim(), 'contact-history', token, { flagShowSystemGenerated: true })
     expect(res.locals.caseSummary.contactSummary).toEqual({
       groupedByKey: 'startDate',
       items: [

--- a/server/controllers/caseSummary/contactHistory/filterContactsByContactType.ts
+++ b/server/controllers/caseSummary/contactHistory/filterContactsByContactType.ts
@@ -1,5 +1,4 @@
 import { ContactSummaryResponse } from '../../../@types/make-recall-decision-api'
-import { ContactHistoryFilters, ContactTypeGroupDecorated } from '../../../@types'
 import { ContactGroupResponse } from '../../../@types/make-recall-decision-api/models/ContactGroupResponse'
 import {
   decorateContactTypes,
@@ -8,6 +7,7 @@ import {
   parseSelectedFilters,
 } from './helpers/contactTypes'
 import { decorateGroups } from './helpers/decorateGroups'
+import { ContactHistoryFilters, ContactTypeGroupDecorated } from '../../../@types/contactTypes'
 
 export const filterContactsByContactType = ({
   filteredContacts,

--- a/server/controllers/caseSummary/contactHistory/filterContactsByDateRange.ts
+++ b/server/controllers/caseSummary/contactHistory/filterContactsByDateRange.ts
@@ -1,5 +1,5 @@
 import { DateTime, Interval } from 'luxon'
-import { ContactHistoryFilters, NamedFormError, ObjectMap } from '../../../@types'
+import { NamedFormError, ObjectMap } from '../../../@types'
 import { ValidationError } from '../../../@types/dates'
 import { convertGmtDatePartsToUtc } from '../../../utils/dates/convert'
 import { ContactSummaryResponse } from '../../../@types/make-recall-decision-api/models/ContactSummaryResponse'
@@ -7,6 +7,7 @@ import { dateHasError, europeLondon } from '../../../utils/dates'
 import { formatValidationErrorMessage, invalidDateInputPart, makeErrorObject } from '../../../utils/errors'
 import { formatDateRange } from '../../../utils/dates/format'
 import { removeParamsFromQueryString } from '../../../utils/utils'
+import { ContactHistoryFilters } from '../../../@types/contactTypes'
 
 const parseDateParts = ({
   fieldPrefix,

--- a/server/controllers/caseSummary/contactHistory/filterContactsBySearch.ts
+++ b/server/controllers/caseSummary/contactHistory/filterContactsBySearch.ts
@@ -1,7 +1,8 @@
 import { ContactSummaryResponse } from '../../../@types/make-recall-decision-api'
 import { isDefined, removeParamsFromQueryString, stripHtmlTags } from '../../../utils/utils'
-import { ContactHistoryFilters, DecoratedContact, NamedFormError, ObjectMap } from '../../../@types'
+import { DecoratedContact, NamedFormError, ObjectMap } from '../../../@types'
 import { formatValidationErrorMessage, makeErrorObject } from '../../../utils/errors'
+import { ContactHistoryFilters } from '../../../@types/contactTypes'
 
 const MINIMUM_SEARCH_TERM_LENGTH = 2
 

--- a/server/controllers/caseSummary/contactHistory/helpers/contactTypes.test.ts
+++ b/server/controllers/caseSummary/contactHistory/helpers/contactTypes.test.ts
@@ -1,5 +1,5 @@
 import { decorateContactTypes, parseSelectedFilters } from './contactTypes'
-import { ContactHistoryFilters } from '../../../../@types'
+import { ContactHistoryFilters } from '../../../../@types/contactTypes'
 
 describe('contactTypes helpers', () => {
   describe('parseSelectedFilters', () => {

--- a/server/controllers/caseSummary/contactHistory/helpers/contactTypes.ts
+++ b/server/controllers/caseSummary/contactHistory/helpers/contactTypes.ts
@@ -1,8 +1,9 @@
-import { ContactTypeDecorated, ContactHistoryFilters, ObjectMap } from '../../../../@types'
 import { isDefined, removeParamsFromQueryString } from '../../../../utils/utils'
 import { ContactGroupResponse } from '../../../../@types/make-recall-decision-api/models/ContactGroupResponse'
 import { ContactSummaryResponse } from '../../../../@types/make-recall-decision-api'
 import logger from '../../../../../logger'
+import { ContactHistoryFilters, ContactTypeDecorated } from '../../../../@types/contactTypes'
+import { ObjectMap } from '../../../../@types'
 
 export const parseSelectedFilters = ({ filters }: { filters: ContactHistoryFilters }) => {
   const { contactTypes } = filters

--- a/server/controllers/caseSummary/contactHistory/helpers/decorateGroups.ts
+++ b/server/controllers/caseSummary/contactHistory/helpers/decorateGroups.ts
@@ -1,6 +1,6 @@
-import { ContactTypeDecorated } from '../../../../@types'
 import { ContactGroupResponse } from '../../../../@types/make-recall-decision-api/models/ContactGroupResponse'
 import { sortList } from '../../../../utils/lists'
+import { ContactTypeCode, ContactTypeDecorated } from '../../../../@types/contactTypes'
 
 // add data for each group and its contacts, for display as filter checkboxes
 export const decorateGroups = ({

--- a/server/controllers/caseSummary/contactHistory/helpers/decorateGroups.ts
+++ b/server/controllers/caseSummary/contactHistory/helpers/decorateGroups.ts
@@ -1,6 +1,6 @@
 import { ContactGroupResponse } from '../../../../@types/make-recall-decision-api/models/ContactGroupResponse'
 import { sortList } from '../../../../utils/lists'
-import { ContactTypeCode, ContactTypeDecorated } from '../../../../@types/contactTypes'
+import { ContactTypeDecorated } from '../../../../@types/contactTypes'
 
 // add data for each group and its contacts, for display as filter checkboxes
 export const decorateGroups = ({

--- a/server/controllers/caseSummary/contactHistory/transformContactHistory.ts
+++ b/server/controllers/caseSummary/contactHistory/transformContactHistory.ts
@@ -1,4 +1,4 @@
-import { ContactHistoryFilters, FeatureFlags } from '../../../@types'
+import { FeatureFlags } from '../../../@types'
 import { ContactHistoryResponse } from '../../../@types/make-recall-decision-api/models/ContactHistoryResponse'
 import { filterContactsByDateRange } from './filterContactsByDateRange'
 import { groupContactsByStartDate } from './groupContactsByStartDate'
@@ -6,6 +6,7 @@ import { filterContactsByContactType } from './filterContactsByContactType'
 import { filterContactsBySearch } from './filterContactsBySearch'
 import { ContactSummaryResponse } from '../../../@types/make-recall-decision-api'
 import { removeFutureContacts } from './removeFutureContacts'
+import { ContactHistoryFilters } from '../../../@types/contactTypes'
 
 export const removeSystemGenerated = (contacts: ContactSummaryResponse[]): ContactSummaryResponse[] =>
   contacts.filter((contact: ContactSummaryResponse) => contact.systemGenerated === false)

--- a/server/controllers/caseSummary/getCaseSection.ts
+++ b/server/controllers/caseSummary/getCaseSection.ts
@@ -18,6 +18,7 @@ import { transformVulnerabilities } from './vulnerabilities/transformVulnerabili
 import { transformRisk } from './risk/transformRisk'
 import { RecommendationsResponse } from '../../@types/make-recall-decision-api'
 import { transformRecommendations } from './recommendations/transformRecommendations'
+import { ContactHistoryFilters } from '../../@types/contactTypes'
 
 export const getCaseSection = async (
   sectionId: CaseSectionId,

--- a/server/controllers/caseSummary/getCaseSection.ts
+++ b/server/controllers/caseSummary/getCaseSection.ts
@@ -1,6 +1,6 @@
 import { ParsedQs } from 'qs'
 import { performance } from 'perf_hooks'
-import { CaseSectionId, ContactHistoryFilters, FeatureFlags } from '../../@types'
+import { CaseSectionId, FeatureFlags } from '../../@types'
 import { CaseSummaryOverviewResponse } from '../../@types/make-recall-decision-api/models/CaseSummaryOverviewResponse'
 import { getCaseSummary } from '../../data/makeDecisionApiClient'
 import { ContactHistoryResponse } from '../../@types/make-recall-decision-api/models/ContactHistoryResponse'
@@ -84,7 +84,10 @@ export const getCaseSection = async (
     case 'contact-history':
       sectionLabel = 'Contact history'
       caseSummaryRaw = await fetchFromCacheOrApi({
-        fetchDataFn: () => getCaseSummary<ContactHistoryResponse>(trimmedCrn, 'contact-history', token),
+        fetchDataFn: () =>
+          getCaseSummary<ContactHistoryResponse>(trimmedCrn, 'contact-history', token, {
+            flagShowSystemGenerated: true,
+          }),
         checkWhetherToCacheDataFn: apiResponse => !isCaseRestrictedOrExcluded(apiResponse.userAccessResponse),
         userId,
         redisKey: `contactHistory:${trimmedCrn}`,

--- a/server/data/makeDecisionApiClient.ts
+++ b/server/data/makeDecisionApiClient.ts
@@ -17,8 +17,16 @@ const featureFlagHeaders = (featureFlags?: FeatureFlags) =>
 export const getPersonsByCrn = (crn: string, token: string): Promise<PersonDetails[]> =>
   restClient(token).get({ path: `${routes.personSearch}?crn=${crn}` }) as Promise<PersonDetails[]>
 
-export const getCaseSummary = <T>(crn: string, sectionId: CaseSectionId, token: string): Promise<T> =>
-  restClient(token).get({ path: `${routes.getCaseSummary}/${crn}/${sectionId}` }) as Promise<T>
+export const getCaseSummary = <T>(
+  crn: string,
+  sectionId: CaseSectionId,
+  token: string,
+  featureFlags?: FeatureFlags
+): Promise<T> =>
+  restClient(token).get({
+    path: `${routes.getCaseSummary}/${crn}/${sectionId}`,
+    headers: featureFlagHeaders(featureFlags),
+  }) as Promise<T>
 
 export const createRecommendation = (
   data: CreateRecommendationRequest,

--- a/server/utils/nunjucks.ts
+++ b/server/utils/nunjucks.ts
@@ -1,7 +1,8 @@
 import nunjucks from 'nunjucks'
 import { DateTime } from 'luxon'
 import { DatePartsParsed } from '../@types/dates'
-import { FormError, ObjectMap, SelectedFilterItem, UrlInfo } from '../@types'
+import { FormError, ObjectMap, UrlInfo } from '../@types'
+import { SelectedFilterItem } from '../@types/contactTypes'
 
 export const dateTimeItems = (fieldName: string, values: DatePartsParsed) => {
   const items = [

--- a/server/views/pages/recommendations/managerReview.njk
+++ b/server/views/pages/recommendations/managerReview.njk
@@ -18,7 +18,7 @@
 
 {% block content %}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             {% if flags.flagConsiderRecall == true and recommendation.recallConsideredList %}
                 {% set infoHtml %}
                     {% if recommendation.managerRecallDecision.selected.value %}


### PR DESCRIPTION
also, load system generated contacts in all cases (whether `flagShowSystemGenerated` is enabled or not) - managing the redis cache is needlessly complex if we store responses with both flag enabled and disabled.