### PR TITLE
mrd-1596_line-breaks-not-appearing-in-text-sent-from-pp-to-spo

### DIFF
--- a/server/views/pages/recommendations/reviewPractitionersConcerns.njk
+++ b/server/views/pages/recommendations/reviewPractitionersConcerns.njk
@@ -21,7 +21,9 @@
                                 <span class="govuk-details__summary-text"> View Answer </span>
                               </summary>
                               <div class="govuk-details__text">
+                                <pre>
                                 {{ triggerLeadingToRecall }}
+                                </pre>
                               </div>
                             </details>
 
@@ -34,7 +36,9 @@
                                 <span class="govuk-details__summary-text"> View Answer </span>
                               </summary>
                               <div class="govuk-details__text">
-                                {{ responseToProbation }}
+                                <pre>
+                                  {{ responseToProbation }}
+                                </pre>
                               </div>
                             </details>
                         </li>


### PR DESCRIPTION
modified reviewPractionersConcern nunjucks template to allow linebreaks around freetext entries