### PR TITLE
Tell Renovate to ignore govuk-frontend

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
       "automerge": true
     }
   ],
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "ignoreDeps": ["govuk-frontend"]
 }


### PR DESCRIPTION
Renovate repeatedly suggests upgrading to v5. We need to do that more intentionally so switching off until we have gone to v5.