### PR TITLE
Tell Renovate to ignore eslint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,5 @@
     }
   ],
   "rebaseWhen": "behind-base-branch",
-  "ignoreDeps": ["govuk-frontend"]
+  "ignoreDeps": ["govuk-frontend", "eslint"]
 }


### PR DESCRIPTION
Temporarily switch off eslint upgrades until v9 is supported by typescript-eslint