### PR TITLE
Suppress Renovate upgrade to @sentry/node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,5 @@
     }
   ],
   "rebaseWhen": "behind-base-branch",
-  "ignoreDeps": ["govuk-frontend", "eslint"]
+  "ignoreDeps": ["govuk-frontend", "eslint", "@sentry/node"]
 }


### PR DESCRIPTION
This is because upgrade to v8 is not straightforward. We need to defer this until there is a pressing need and/or more time to look at it.