### PR TITLE
bump circleci ubuntu image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
 
   e2e_local_test:
     machine:
-      image: ubuntu-2004:2023.07.1
+      image: ubuntu-2204:current
     parallelism: << pipeline.parameters.e2e-parallelism >>
     steps:
       - run:


### PR DESCRIPTION
CircleCI 2004 Ubuntu images are about to reach end-of-life...bumped