### PR TITLE
Mrd 2529 display new osp values

### DIFF
--- a/api/responses/get-case-risk.json
+++ b/api/responses/get-case-risk.json
@@ -77,13 +77,13 @@
           "score": 18,
           "type": "RSR"
         },
-        "OSPC": {
+        "OSPDC": {
           "level": "LOW",
-          "type": "OSP/C"
+          "type": "OSP/DC"
         },
-        "OSPI": {
+        "OSPIIC": {
           "level": "MEDIUM",
-          "type": "OSP/I"
+          "type": "OSP/IIC"
         },
         "OGRS": {
           "level": "MEDIUM",

--- a/api/responses/get-case-risk.json
+++ b/api/responses/get-case-risk.json
@@ -114,13 +114,13 @@
             "score": 18,
             "type": "RSR"
           },
-          "OSPC": {
+          "OSPDC": {
             "level": "LOW",
-            "type": "OSP/C"
+            "type": "OSP/DC"
           },
-          "OSPI": {
+          "OSPIIC": {
             "level": "MEDIUM",
-            "type": "OSP/I"
+            "type": "OSP/IIC"
           },
           "OGRS": {
             "level": "MEDIUM",

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -44,6 +44,13 @@ To get debug output when running cypress:
 
 `DEBUG=cypress:* npm run int-test-ui`
 
+If you want to run a specific test, rather than all the tests, append `-- --spec=<path-to-test>` to the call (only works
+for `int-test` script):
+
+```
+npm run int-test -- --spec=integration_tests/integration/risk.spec.ts
+```
+
 ## Accessibility tests
 
 These run in Cypress and test a selection of pages against accessibility standards using Axe.
@@ -52,7 +59,7 @@ These run in Cypress and test a selection of pages against accessibility standar
 docker compose -f docker-compose-test.yml up -d
 ```
 
-then 
+then
 
 ```
 npm run start-feature

--- a/integration_tests/integration/risk.spec.ts
+++ b/integration_tests/integration/risk.spec.ts
@@ -2,16 +2,27 @@ import getCaseRiskResponse from '../../api/responses/get-case-risk.json'
 import { routeUrls } from '../../server/routes/routeUrls'
 import getCaseRiskNoDataResponse from '../../api/responses/get-case-risk-no-data.json'
 import { riskLevelLabel } from '../../server/utils/nunjucks'
+import completeRecommendationResponse from '../../api/responses/get-recommendation.json'
 
 context('Risk page', () => {
   const crn = 'X34983'
 
   beforeEach(() => {
+    cy.task('reset')
+    cy.window().then(win => win.sessionStorage.clear())
+    cy.task('getUser', { user: 'USER1', statusCode: 200, response: { homeArea: { code: 'N07', name: 'London' } } })
     cy.signIn()
+
+    // Mock the API calls
+    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
+    cy.task('getRecommendation', {
+      statusCode: 200,
+      response: { ...completeRecommendationResponse },
+    })
+    cy.task('getStatuses', { statusCode: 200, response: [] })
   })
 
   it('shows RoSH, MAPPA and predictor scores', () => {
-    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
     cy.visit(`${routeUrls.cases}/${crn}/risk`)
     cy.pageHeading().should('equal', 'Risk for Paula Smith')
     cy.getElement({ qaAttr: 'banner-latest-complete-assessment' }).should('not.exist')
@@ -74,7 +85,6 @@ context('Risk page', () => {
   })
 
   it('shows predictor scores with old OSP values', () => {
-    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
     const currentScore = {
       date: '2021-10-24',
       scores: {
@@ -110,7 +120,6 @@ context('Risk page', () => {
   })
 
   it('shows messages if RoSH / MAPPA / predictor score data is not found', () => {
-    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
     cy.task('getCase', {
       sectionId: 'risk',
       statusCode: 200,
@@ -173,7 +182,6 @@ context('Risk page', () => {
   })
 
   it('shows messages if an error occurs fetching RoSH / MAPPA / predictor score data', () => {
-    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
     cy.task('getCase', {
       sectionId: 'risk',
       statusCode: 200,
@@ -216,7 +224,6 @@ context('Risk page', () => {
   })
 
   it('shows messages if RoSH data empty', () => {
-    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
     cy.task('getCase', {
       sectionId: 'risk',
       statusCode: 200,
@@ -239,7 +246,6 @@ context('Risk page', () => {
 
   describe('Timeline', () => {
     it('Predictor scores and RoSH history available', () => {
-      cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
       cy.task('getCase', {
         sectionId: 'risk',
         statusCode: 200,
@@ -267,8 +273,8 @@ context('Risk page', () => {
       let opts = { parent: '[data-qa="timeline-item-2"]' }
       cy.getElement('13 July 2021', opts).should('be.visible')
       cy.getElement('RSR HIGH 18', opts).should('be.visible')
-      cy.getElement('OSP/C LOW', opts).should('be.visible')
-      cy.getElement('OSP/I MEDIUM', opts).should('be.visible')
+      cy.getElement('OSP/DC LOW', opts).should('be.visible')
+      cy.getElement('OSP/IIC MEDIUM', opts).should('be.visible')
       cy.getElement('OGRS 1YR MEDIUM 10', opts).should('be.visible')
       cy.getElement('OGRS 2YR MEDIUM 20', opts).should('be.visible')
       cy.getElement('OGP 1YR HIGH 56', opts).should('be.visible')
@@ -293,7 +299,6 @@ context('Risk page', () => {
     })
 
     it('errors fetching both predictor and RoSH history', () => {
-      cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
       cy.task('getCase', {
         sectionId: 'risk',
         statusCode: 200,
@@ -307,7 +312,6 @@ context('Risk page', () => {
     })
 
     it('error fetching predictor scores', () => {
-      cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
       cy.task('getCase', {
         sectionId: 'risk',
         statusCode: 200,
@@ -328,7 +332,6 @@ context('Risk page', () => {
     })
 
     it('error fetching RoSH history', () => {
-      cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
       cy.task('getCase', {
         sectionId: 'risk',
         statusCode: 200,
@@ -349,7 +352,6 @@ context('Risk page', () => {
     })
 
     it('score timeline - hide individual scores if missing', () => {
-      cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
       cy.task('getCase', {
         sectionId: 'risk',
         statusCode: 200,
@@ -381,7 +383,6 @@ context('Risk page', () => {
   })
 
   it('shows a message if the assessment is incomplete', () => {
-    cy.task('getActiveRecommendation', { statusCode: 200, response: { recommendationId: 12345 } })
     cy.task('getCase', {
       sectionId: 'risk',
       statusCode: 200,

--- a/server/controllers/caseSummary/caseSummaryController.ts
+++ b/server/controllers/caseSummary/caseSummaryController.ts
@@ -60,7 +60,7 @@ function isClosedForProbationServices(statuses: Status[]): boolean {
   return isWithPpcs || isPPDocumentCreated
 }
 
-// Helper function to return only active statuses for the currect active recommendation
+// Helper function to return only active statuses for the current active recommendation
 async function getActiveStatuses(activeRecommendation: ActiveRecommendation, token: string) {
   return (
     await getStatuses({

--- a/server/views/components/predictor-score/template.njk
+++ b/server/views/components/predictor-score/template.njk
@@ -1,38 +1,34 @@
 {% from "components/predictor-indicator/macro.njk" import predictorIndicator %}
-
 {% set scoreLabelClass = '' %}
 
-{% if predictorScore.level === 'LOW' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I')%}
+{% if predictorScore.level === 'LOW' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC')%}
     {% set scoreLabelClass = 'score-label-wrapper--low score-label-wrapper--position-one-of-three' %}
-{% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I') %}
+{% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC') %}
     {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-three' %}
-{% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I') %}
+{% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC') %}
     {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-three' %}
-{% elif predictorScore.level === 'LOW' and predictorScore.type  === 'OSP/C' %}
+{% elif predictorScore.level === 'LOW' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC')%}
     {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-one-of-four' %}
-{% elif predictorScore.level === 'MEDIUM' and predictorScore.type  === 'OSP/C' %}
+{% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
     {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-four' %}
-{% elif predictorScore.level === 'HIGH' and predictorScore.type  === 'OSP/C' %}
+{% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
     {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-four' %}
-{% elif predictorScore.level === 'VERY HIGH' and predictorScore.type  === 'OSP/C' %}
+{% elif predictorScore.level === 'VERY HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
     {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
 {% endif %}
-
 {% set barTypeClass = '' %}
-
 {% switch predictorScore.type %}
     {% case 'RSR' %}
-        {% set barTypeClass = 'score-bar'%}
+        {% set barTypeClass = 'score-bar' %}
         {% set showScore = true %}
-    {% case 'OSP/I' %}
-        {% set barTypeClass = 'score-bar--small'%}
+    {% case 'OSP/I' %}{% case 'OSP/IIC' %}
+        {% set barTypeClass = 'score-bar--small' %}
         {% set showScore = false %}
-    {% case 'OSP/C' %}
+    {% case 'OSP/C' %}{% case 'OSP/DC' %}
         {% set barTypeClass = 'score-bar--small score-bar--small-fourths' %}
         {% set showScore = false %}
-{% endswitch %}
-
-{% if predictorScore.level === 'NOT_APPLICABLE' %}
+    {% endswitch %}
+{% if predictorScore.level === 'NOT APPLICABLE' %}
 <div class="predictor-score govuk-body">
     <p class="govuk-body">No relevant sexual offences</p>
 </div>
@@ -53,10 +49,10 @@
         <div>
             <span></span>
         </div>
-        {% if predictorScore.type === 'OSP/C' %}
-        <div>
-            <span></span>
-        </div>
+        {% if predictorScore.type === 'OSP/C' or predictorScore.type === 'OSP/DC' %}
+            <div>
+                <span></span>
+            </div>
         {% endif %}
     </div>
 </div>

--- a/server/views/components/predictor-score/template.njk
+++ b/server/views/components/predictor-score/template.njk
@@ -1,4 +1,5 @@
 {% from "components/predictor-indicator/macro.njk" import predictorIndicator %}
+
 {% set scoreLabelClass = '' %}
 
 {% if predictorScore.level === 'LOW' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC')%}
@@ -16,7 +17,9 @@
 {% elif predictorScore.level === 'VERY HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
     {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
 {% endif %}
+
 {% set barTypeClass = '' %}
+
 {% switch predictorScore.type %}
     {% case 'RSR' %}
         {% set barTypeClass = 'score-bar' %}
@@ -27,8 +30,8 @@
     {% case 'OSP/C' %}{% case 'OSP/DC' %}
         {% set barTypeClass = 'score-bar--small score-bar--small-fourths' %}
         {% set showScore = false %}
-    {% endswitch %}
-{% if predictorScore.level === 'NOT APPLICABLE' %}
+{% endswitch %}
+{% if predictorScore.level === 'NOT_APPLICABLE' %}
 <div class="predictor-score govuk-body">
     <p class="govuk-body">No relevant sexual offences</p>
 </div>
@@ -50,9 +53,9 @@
             <span></span>
         </div>
         {% if predictorScore.type === 'OSP/C' or predictorScore.type === 'OSP/DC' %}
-            <div>
-                <span></span>
-            </div>
+        <div>
+            <span></span>
+        </div>
         {% endif %}
     </div>
 </div>

--- a/server/views/components/predictor-timeline-section/template.njk
+++ b/server/views/components/predictor-timeline-section/template.njk
@@ -26,6 +26,8 @@
     <div data-js='predictor-timeline__section' class="predictor-timeline-section predictor-timeline-section--hidden" id='scores-section-{{ params.index }}'>
         <ul class="govuk-list">
             {% if params.item.scores.RSR %}<li>{{ predictorTimelineItem({ type: params.item.scores.RSR.type, score: params.item.scores.RSR.score, level: params.item.scores.RSR.level }) }}</li>{% endif %}
+            {% if params.item.scores.OSPDC %}<li>{{ predictorTimelineItem({ type: params.item.scores.OSPDC.type, score: params.item.scores.OSPDC.score, level: params.item.scores.OSPDC.level }) }}</li>{% endif %}
+            {% if params.item.scores.OSPIIC %}<li>{{ predictorTimelineItem({ type: params.item.scores.OSPIIC.type, score: params.item.scores.OSPIIC.score, level: params.item.scores.OSPIIC.level }) }}</li>{% endif %}
             {% if params.item.scores.OSPC %}<li>{{ predictorTimelineItem({ type: params.item.scores.OSPC.type, score: params.item.scores.OSPC.score, level: params.item.scores.OSPC.level }) }}</li>{% endif %}
             {% if params.item.scores.OSPI %}<li>{{ predictorTimelineItem({ type: params.item.scores.OSPI.type, score: params.item.scores.OSPI.score, level: params.item.scores.OSPI.level }) }}</li>{% endif %}
             {% if params.item.scores.OGRS %}

--- a/server/views/partials/caseRisk.njk
+++ b/server/views/partials/caseRisk.njk
@@ -91,41 +91,85 @@
         {% endif %}
 
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-half-from-desktop">
-                <h2 class="govuk-heading-m score-header govuk-!-margin-bottom-0" data-analytics-event-scroll="OSP/C score">
-                    OSP/C
-                </h2>
-                <div data-qa='scale-ospc'>
-                    {% if caseSummary.predictorScores.current.scores.OSPC %}
-                        <div class="text-secondary govuk-body govuk-!-margin-bottom-2">
-                            Last updated: {{ formatDateTimeFromIsoString({ isoDate: caseSummary.predictorScores.current.date, dateOnly: true }) }}
-                        </div>
-                    <div aria-hidden="true">
-                        {{ predictorScore(caseSummary.predictorScores.current.scores.OSPC) }}
+            {# If we don't have OSP/DC or OSP/IIC values, but also don't have OSP/C or OSP/I ones, we want
+               the labels for the former to show above the "Data not avilable" messages.#}
+            {% if caseSummary.predictorScores.current.scores.OSPDC or caseSummary.predictorScores.current.scores.OSPIIC
+                or not (caseSummary.predictorScores.current.scores.OSPC or caseSummary.predictorScores.current.scores.OSPI) %}
+                <div class="govuk-grid-column-one-half-from-desktop">
+                    <h2 class="govuk-heading-m score-header govuk-!-margin-bottom-0"
+                        data-analytics-event-scroll="OSP/DC score">
+                        OSP/DC
+                    </h2>
+                    <div data-qa='scale-ospdc'>
+                        {% if caseSummary.predictorScores.current.scores.OSPDC %}
+                            <div class="text-secondary govuk-body govuk-!-margin-bottom-2">
+                                Last updated: {{ formatDateTimeFromIsoString({ isoDate: caseSummary.predictorScores.current.date, dateOnly: true }) }}
+                            </div>
+                            <div aria-hidden="true">
+                                {{ predictorScore(caseSummary.predictorScores.current.scores.OSPDC) }}
+                            </div>
+                            <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPDC.level }}</div>
+                        {% else %}
+                            <p class='govuk-body' data-qa='ospdc-missing'>Data not available.</p>
+                        {% endif %}
                     </div>
-                    <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPC.level }}</div>
-                    {% else %}
-                        <p class='govuk-body' data-qa='ospc-missing'>Data not available.</p>
-                    {% endif %}
                 </div>
-            </div>
-            <div class="govuk-grid-column-one-half-from-desktop">
-                <h2 class="govuk-heading-m score-header govuk-!-margin-bottom-0" data-analytics-event-scroll="OSP/I score">
-                    OSP/I
-                </h2>
-                <div data-qa='scale-ospi'>
-                    {% if caseSummary.predictorScores.current.scores.OSPI %}
-                        <div class="text-secondary govuk-body govuk-!-margin-bottom-2">
-                            Last updated: {{ formatDateTimeFromIsoString({ isoDate: caseSummary.predictorScores.current.date, dateOnly: true }) }}
-                        </div>
-                    <div aria-hidden="true">
-                        {{ predictorScore(caseSummary.predictorScores.current.scores.OSPI) }}
+                <div class="govuk-grid-column-one-half-from-desktop">
+                    <h2 class="govuk-heading-m score-header govuk-!-margin-bottom-0"
+                        data-analytics-event-scroll="OSP/IIC score">
+                        OSP/IIC
+                    </h2>
+                    <div data-qa='scale-ospiic'>
+                        {% if caseSummary.predictorScores.current.scores.OSPIIC %}
+                            <div class="text-secondary govuk-body govuk-!-margin-bottom-2">
+                                Last updated: {{ formatDateTimeFromIsoString({ isoDate: caseSummary.predictorScores.current.date, dateOnly: true }) }}
+                            </div>
+                            <div aria-hidden="true">
+                                {{ predictorScore(caseSummary.predictorScores.current.scores.OSPIIC) }}
+                            </div>
+                            <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPIIC.level }}</div>
+                        {% else %}
+                            <p class='govuk-body' data-qa='ospiic-missing'>Data not available.</p>
+                        {% endif %}
                     </div>
-                        <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPI.level }}</div>
-                    {% else %}
-                        <p class='govuk-body' data-qa='ospi-missing'>Data not available.</p>
-                    {% endif %}</div>
-            </div>
+                </div>
+            {% else %}
+                <div class="govuk-grid-column-one-half-from-desktop">
+                    <h2 class="govuk-heading-m score-header govuk-!-margin-bottom-0" data-analytics-event-scroll="OSP/C score">
+                        OSP/C
+                    </h2>
+                    <div data-qa='scale-ospc'>
+                        {% if caseSummary.predictorScores.current.scores.OSPC %}
+                            <div class="text-secondary govuk-body govuk-!-margin-bottom-2">
+                                Last updated: {{ formatDateTimeFromIsoString({ isoDate: caseSummary.predictorScores.current.date, dateOnly: true }) }}
+                            </div>
+                        <div aria-hidden="true">
+                            {{ predictorScore(caseSummary.predictorScores.current.scores.OSPC) }}
+                        </div>
+                        <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPC.level }}</div>
+                        {% else %}
+                            <p class='govuk-body' data-qa='ospc-missing'>Data not available.</p>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="govuk-grid-column-one-half-from-desktop">
+                    <h2 class="govuk-heading-m score-header govuk-!-margin-bottom-0" data-analytics-event-scroll="OSP/I score">
+                        OSP/I
+                    </h2>
+                    <div data-qa='scale-ospi'>
+                        {% if caseSummary.predictorScores.current.scores.OSPI %}
+                            <div class="text-secondary govuk-body govuk-!-margin-bottom-2">
+                                Last updated: {{ formatDateTimeFromIsoString({ isoDate: caseSummary.predictorScores.current.date, dateOnly: true }) }}
+                            </div>
+                        <div aria-hidden="true">
+                            {{ predictorScore(caseSummary.predictorScores.current.scores.OSPI) }}
+                        </div>
+                            <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPI.level }}</div>
+                        {% else %}
+                            <p class='govuk-body' data-qa='ospi-missing'>Data not available.</p>
+                        {% endif %}</div>
+                </div>
+            {% endif %}
         </div>
         </div>
 

--- a/server/views/partials/caseRisk.njk
+++ b/server/views/partials/caseRisk.njk
@@ -91,8 +91,9 @@
         {% endif %}
 
         <div class="govuk-grid-row">
-            {# If we don't have OSP/DC or OSP/IIC values, but also don't have OSP/C or OSP/I ones, we want
-               the labels for the former to show above the "Data not avilable" messages.#}
+            {# If no OSP values of any kind are available, we want the labels for the new type of OSP values (i.e.
+               OSP/DC and OSP/IIC) to show above the "Data not avilable" messages. This is why we check old and new values
+               at this point. #}
             {% if caseSummary.predictorScores.current.scores.OSPDC or caseSummary.predictorScores.current.scores.OSPIIC
                 or not (caseSummary.predictorScores.current.scores.OSPC or caseSummary.predictorScores.current.scores.OSPI) %}
                 <div class="govuk-grid-column-one-half-from-desktop">


### PR DESCRIPTION
ARN switched to a different set of OSP values, OSP/DC and OSP/IIC.
With this change, the new values are displayed instead of the old
ones if present, with the relevant labels updated accordingly. If
neither new nor old values are present, the new labels are
displayed above the 'Data not available.' messages.

The timeline will also reflect the new and old values.