### PR TITLE
MRD-2529 Fix OSP/C & OSP/DC label displays

### DIFF
--- a/server/utils/nunjucks.ts
+++ b/server/utils/nunjucks.ts
@@ -68,6 +68,15 @@ export const riskLevelLabel = (level: string) => {
   }
 }
 
+export const ospdcLevelLabel = (level: string) => {
+  switch (level) {
+    case 'VERY_HIGH':
+      return 'VERY HIGH'
+    default:
+      return level
+  }
+}
+
 export const roshYesNoLabel = (level: string | null) => {
   switch (level) {
     case 'YES':

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -12,6 +12,7 @@ import {
   removeUndefinedListItems,
   selectedFilterItems,
   riskLevelLabel,
+  ospdcLevelLabel,
   defaultValue,
   roshYesNoLabel,
   formatDateFilterQueryString,
@@ -90,6 +91,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('nextPageLinkUrl', nextPageLinkUrl)
   njkEnv.addGlobal('possessiveSuffix', possessiveSuffix)
   njkEnv.addGlobal('riskLevelLabel', riskLevelLabel)
+  njkEnv.addGlobal('ospdcLevelLabel', ospdcLevelLabel)
   njkEnv.addGlobal('roshYesNoLabel', roshYesNoLabel)
   njkEnv.addGlobal('isDefined', isDefined)
   njkEnv.addGlobal('formatDateFilterQueryString', formatDateFilterQueryString)

--- a/server/views/components/predictor-indicator/template.njk
+++ b/server/views/components/predictor-indicator/template.njk
@@ -1,6 +1,6 @@
 <div class="score-label__card">
     <div class="score-label__card-top">
-        <h3>{{ predictorScore.level }}</h3>
+        <h3>{{ ospdcLevelLabel(predictorScore.level) }}</h3>
         <p>{{ predictorScore.type }}</p>
     </div>
     {% if showScore and predictorScore.score %}

--- a/server/views/components/predictor-score/template.njk
+++ b/server/views/components/predictor-score/template.njk
@@ -14,7 +14,7 @@
     {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-four' %}
 {% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
     {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-four' %}
-{% elif predictorScore.level === 'VERY HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
+{% elif predictorScore.level === 'VERY_HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
     {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
 {% endif %}
 

--- a/server/views/components/predictor-score/template.njk
+++ b/server/views/components/predictor-score/template.njk
@@ -2,20 +2,26 @@
 
 {% set scoreLabelClass = '' %}
 
-{% if predictorScore.level === 'LOW' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC')%}
-    {% set scoreLabelClass = 'score-label-wrapper--low score-label-wrapper--position-one-of-three' %}
-{% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC') %}
-    {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-three' %}
-{% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I' or predictorScore.type === 'OSP/IIC') %}
-    {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-three' %}
-{% elif predictorScore.level === 'LOW' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC')%}
-    {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-one-of-four' %}
-{% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
-    {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-four' %}
-{% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
-    {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-four' %}
-{% elif predictorScore.level === 'VERY_HIGH' and (predictorScore.type  === 'OSP/C'  or predictorScore.type === 'OSP/DC') %}
-    {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
+{% if ['RSR', 'OSP/I', 'OSP/IIC'].includes(predictorScore.type) %}
+    {% switch predictorScore.level %}
+        {% case 'LOW' %}
+            {% set scoreLabelClass = 'score-label-wrapper--low score-label-wrapper--position-one-of-three' %}
+        {% case 'MEDIUM' %}
+            {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-three' %}
+        {% case 'HIGH' %}
+            {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-three' %}
+    {% endswitch %}
+{% elif ['OSP/C', 'OSP/DC'].includes(predictorScore.type) %}
+    {% switch predictorScore.level %}
+        {% case 'LOW'%}
+            {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-one-of-four' %}
+        {% case 'MEDIUM' %}
+            {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-four' %}
+        {% case 'HIGH' %}
+            {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-four' %}
+        {% case 'VERY_HIGH' %}
+            {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
+    {% endswitch %}
 {% endif %}
 
 {% set barTypeClass = '' %}

--- a/server/views/components/predictor-score/template.njk
+++ b/server/views/components/predictor-score/template.njk
@@ -14,7 +14,7 @@
 {% elif ['OSP/C', 'OSP/DC'].includes(predictorScore.type) %}
     {% switch predictorScore.level %}
         {% case 'LOW'%}
-            {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-one-of-four' %}
+            {% set scoreLabelClass = 'score-label-wrapper--low score-label-wrapper--position-one-of-four' %}
         {% case 'MEDIUM' %}
             {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-four' %}
         {% case 'HIGH' %}

--- a/server/views/partials/caseRisk.njk
+++ b/server/views/partials/caseRisk.njk
@@ -109,7 +109,7 @@
                             <div aria-hidden="true">
                                 {{ predictorScore(caseSummary.predictorScores.current.scores.OSPDC) }}
                             </div>
-                            <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPDC.level }}</div>
+                            <div class='govuk-visually-hidden'>Level: {{ ospdcLevelLabel(caseSummary.predictorScores.current.scores.OSPDC.level) }}</div>
                         {% else %}
                             <p class='govuk-body' data-qa='ospdc-missing'>Data not available.</p>
                         {% endif %}
@@ -147,7 +147,7 @@
                         <div aria-hidden="true">
                             {{ predictorScore(caseSummary.predictorScores.current.scores.OSPC) }}
                         </div>
-                        <div class='govuk-visually-hidden'>Level: {{ caseSummary.predictorScores.current.scores.OSPC.level }}</div>
+                        <div class='govuk-visually-hidden'>Level: {{ ospdcLevelLabel(caseSummary.predictorScores.current.scores.OSPC.level) }}</div>
                         {% else %}
                             <p class='govuk-body' data-qa='ospc-missing'>Data not available.</p>
                         {% endif %}


### PR DESCRIPTION
The check on the level value was incorrect for OSP/C and OSP/DC values in the
case of a value of VERY_HIGH: the value itself is 'VERY_HIGH', with an
underscore, while the value checked against was 'VERY HIGH', with a space in
between. This was resulting in the label marker for VERY_HIGH cases to be
displayed in the middle of the rating bar, rather than on the right-most
section, due to the label not having the right class assigned to it. This is
corrected here.

It was also noticed that the wrong CSS class was assigned to the display label
for LOW OSP/C and OSP/DC scores: the one corresponding to the MEDIUM one
was used instead. This is corrected here.