### PR TITLE
bump of cypress-multi-reports to a ver whose mocha dependency no longer depends on nanoid CVE-2024-55565

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "concurrently": "^9.0.0",
         "cypress": "^13.7.2",
         "cypress-axe": "^1.5.0",
-        "cypress-multi-reporters": "^1.6.4",
+        "cypress-multi-reporters": "^2.0.4",
         "cypress-terminal-report": "^7.0.0",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -5984,12 +5984,12 @@
       }
     },
     "node_modules/cypress-multi-reporters": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/cypress-multi-reporters/-/cypress-multi-reporters-1.6.4.tgz",
-      "integrity": "sha512-3xU2t6pZjZy/ORHaCvci5OT1DAboS4UuMMM8NBAizeb2C9qmHt+cgAjXgurazkwkPRdO7ccK39M5ZaPCju0r6A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/cypress-multi-reporters/-/cypress-multi-reporters-2.0.4.tgz",
+      "integrity": "sha512-TZKzSfo8ReU2Fuj1n90gi4Ocw1a/nh6utiq9g0wy27muq1/IjZXdR97WXkV0to2vd8NRldXt+tuKEmxQrp8LDg==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -5998,6 +5998,29 @@
       "peerDependencies": {
         "mocha": ">=3.1.2"
       }
+    },
+    "node_modules/cypress-multi-reporters/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cypress-multi-reporters/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/cypress-terminal-report": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "concurrently": "^9.0.0",
     "cypress": "^13.7.2",
     "cypress-axe": "^1.5.0",
-    "cypress-multi-reporters": "^1.6.4",
+    "cypress-multi-reporters": "^2.0.4",
     "cypress-terminal-report": "^7.0.0",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",


### PR DESCRIPTION
Bump of cypress-multi-reports to a version whose mocha dependency no longer depends on nanoid

make-recall-decision-ui@0.0.1 /Users/rick.livesey/git/make-recall-decision-ui
└─┬ cypress-multi-reporters@1.6.4
  └─┬ mocha@10.2.0
    └── nanoid@3.3.3

-cypress-multi-reporters@1.6.4 depends on mocha@10.2.0
-mocha@10.2.0 is the last version with a nanoid dependency (this was the version we used), the next version (10.3.0) loses it
-cypress-multi-reporters@2.0.4 (the latest) depends on mocha 11.0.1
 
https://github.com/advisories/GHSA-mwcw-c2x4-8c55