### PR TITLE
mrd 2612 display graceful message when mappa value unknown

### DIFF
--- a/integration_tests/integration/recommendation.spec.ts
+++ b/integration_tests/integration/recommendation.spec.ts
@@ -2356,6 +2356,34 @@ context('Make a recommendation', () => {
       cy.getText('mappaLevel').should('contain', 'Level 0')
     })
 
+    it('edit MAPPA Level - unknown', () => {
+      const completeRecommendationResponseWithoutMappaLevel = JSON.parse(JSON.stringify(completeRecommendationResponse))
+      delete completeRecommendationResponseWithoutMappaLevel.personOnProbation.mappa.level
+
+      cy.task('getRecommendation', {
+        statusCode: 200,
+        response: {
+          ...completeRecommendationResponseWithoutMappaLevel,
+          prisonOffender: {},
+          bookRecallToPpud: {},
+          ppudOffender: {},
+        },
+      })
+      cy.task('getStatuses', { statusCode: 200, response: [{ name: 'SENT_TO_PPCS', active: true }] })
+      cy.task('getReferenceList', {
+        name: 'mappa-levels',
+        statusCode: 200,
+        response: {
+          values: ['Level 1 – Single Agency Management', 'Level 2 – Local Inter-Agency Management', 'Level 3 – MAPPP'],
+        },
+      })
+
+      cy.visit(`/recommendations/252523937/edit-mappa-level`)
+      cy.pageHeading().should('contain', 'Edit MAPPA level')
+
+      cy.getText('mappaLevel').should('contain', 'Unknown')
+    })
+
     it('select index offence', () => {
       cy.task('getRecommendation', {
         statusCode: 200,

--- a/server/views/pages/recommendations/editMappaLevel.njk
+++ b/server/views/pages/recommendations/editMappaLevel.njk
@@ -17,7 +17,13 @@
                 <h2 class='govuk-heading-m'>From Part A</h2>
                 <div class="govuk-text-list__row">
                     <div class="govuk-text-list__key">MAPPA Level</div>
-                    <div class="govuk-text-list__value" data-qa="mappaLevel"> Level {{ recommendation.personOnProbation.mappa.level }}</div>
+                    <div class="govuk-text-list__value" data-qa="mappaLevel">
+                        {% if recommendation.personOnProbation.mappa.level is defined %}
+                            Level {{ recommendation.personOnProbation.mappa.level }}
+                        {% else %}
+                            Unknown
+                        {% endif %}
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Given a PPCS user is Booking On a PoP using CaR
When they visit the ‘Edit MAPPA’ page and the MAPPA does not have a value
Then display the following:

From the Part A

MAPPA level: Unknown 