### PR TITLE
MRD-2609 Set 'Sentenced Under' field in PPUD Sentence

### DIFF
--- a/integration_tests/integration/recommendation.spec.ts
+++ b/integration_tests/integration/recommendation.spec.ts
@@ -2224,6 +2224,7 @@ context('Make a recommendation', () => {
           prisonOffender: {},
           bookRecallToPpud: {
             legislationReleasedUnder: 'CJA1',
+            legislationSentencedUnder: 'CJA1',
           },
           ppudOffender: {},
         },

--- a/server/@types/make-recall-decision-api/models/PpudUpdateSentenceRequest.ts
+++ b/server/@types/make-recall-decision-api/models/PpudUpdateSentenceRequest.ts
@@ -9,6 +9,7 @@ export type PpudUpdateSentenceRequest = {
   espExtendedPeriod?: YearMonth,
   sentenceExpiryDate: string,
   sentencingCourt: string,
+  sentencedUnder: string,
 };
 
 export type SentenceLength = {

--- a/server/@types/make-recall-decision-api/models/RecommendationResponse.ts
+++ b/server/@types/make-recall-decision-api/models/RecommendationResponse.ts
@@ -175,6 +175,7 @@ export type BookRecallToPpud = {
   gender?: string,
   ethnicity: string,
   legislationReleasedUnder?: string,
+  legislationSentencedUnder?: string,
   releasingPrison?: string,
   minute?: string,
 }

--- a/server/booking/createOrUpdateSentence.test.ts
+++ b/server/booking/createOrUpdateSentence.test.ts
@@ -56,40 +56,42 @@ describe('update sentence', () => {
       },
     } as unknown as RecommendationResponse
 
-    const result = await createOrUpdateSentence(bookingMemento, recommendation, 'token', { xyz: true })
+    const token = 'token'
 
-    expect(ppudUpdateSentence).toHaveBeenCalledWith('token', '767', '444', {
-      custodyType: 'Determinate',
-      mappaLevel: 'Level 2 - local inter-agency management',
-      dateOfSentence: '2016-01-01',
-      licenceExpiryDate: '2018-02-02',
-      releaseDate: '2017-03-03',
-      sentenceExpiryDate: '2019-04-04',
-      sentencingCourt: 'court desc',
+    const featureFlags = { xyz: true }
+
+    const result = await createOrUpdateSentence(bookingMemento, recommendation, token, featureFlags)
+
+    expect(ppudUpdateSentence).toHaveBeenCalledWith(token, bookingMemento.offenderId, bookingMemento.sentenceId, {
+      custodyType: recommendation.bookRecallToPpud.custodyType,
+      mappaLevel: recommendation.bookRecallToPpud.mappaLevel,
+      dateOfSentence: recommendation.nomisIndexOffence.allOptions[0].sentenceDate,
+      licenceExpiryDate: recommendation.nomisIndexOffence.allOptions[0].licenceExpiryDate,
+      releaseDate: recommendation.nomisIndexOffence.allOptions[0].releaseDate,
+      sentenceExpiryDate: recommendation.nomisIndexOffence.allOptions[0].sentenceEndDate,
+      sentencingCourt: recommendation.nomisIndexOffence.allOptions[0].courtDescription,
       sentenceLength: {
-        partDays: 1,
-        partMonths: 2,
-        partYears: 3,
+        partDays: recommendation.nomisIndexOffence.allOptions[0].terms[0].days,
+        partMonths: recommendation.nomisIndexOffence.allOptions[0].terms[0].months,
+        partYears: recommendation.nomisIndexOffence.allOptions[0].terms[0].years,
       },
     })
 
     expect(updateRecommendation).toHaveBeenCalledWith({
-      recommendationId: '1',
+      recommendationId: recommendation.id,
       valuesToSave: {
         bookingMemento: {
-          offenderId: '767',
-          sentenceId: '444',
+          offenderId: bookingMemento.offenderId,
+          sentenceId: bookingMemento.sentenceId,
           stage: 'SENTENCE_BOOKED',
         },
       },
-      token: 'token',
-      featureFlags: {
-        xyz: true,
-      },
+      token,
+      featureFlags,
     })
     expect(result).toEqual({
-      offenderId: '767',
-      sentenceId: '444',
+      offenderId: bookingMemento.offenderId,
+      sentenceId: bookingMemento.sentenceId,
       stage: 'SENTENCE_BOOKED',
     })
   })
@@ -134,42 +136,45 @@ describe('update sentence', () => {
       },
     } as unknown as RecommendationResponse
 
-    ;(ppudCreateSentence as jest.Mock).mockResolvedValue({ sentence: { id: '445' } })
+    const sentence = { id: '445' }
+    ;(ppudCreateSentence as jest.Mock).mockResolvedValue({ sentence })
 
-    const result = await createOrUpdateSentence(bookingMemento, recommendation, 'token', { xyz: true })
+    const token = 'token'
 
-    expect(ppudCreateSentence).toHaveBeenCalledWith('token', '767', {
-      custodyType: 'Determinate',
-      mappaLevel: 'Level 2 - local inter-agency management',
-      dateOfSentence: '2016-01-01',
-      licenceExpiryDate: '2018-02-02',
-      releaseDate: '2017-03-03',
-      sentenceExpiryDate: '2019-04-04',
-      sentencingCourt: 'court desc',
+    const featureFlags = { xyz: true }
+
+    const result = await createOrUpdateSentence(bookingMemento, recommendation, token, featureFlags)
+
+    expect(ppudCreateSentence).toHaveBeenCalledWith(token, bookingMemento.offenderId, {
+      custodyType: recommendation.bookRecallToPpud.custodyType,
+      mappaLevel: recommendation.bookRecallToPpud.mappaLevel,
+      dateOfSentence: recommendation.nomisIndexOffence.allOptions[0].sentenceDate,
+      licenceExpiryDate: recommendation.nomisIndexOffence.allOptions[0].licenceExpiryDate,
+      releaseDate: recommendation.nomisIndexOffence.allOptions[0].releaseDate,
+      sentenceExpiryDate: recommendation.nomisIndexOffence.allOptions[0].sentenceEndDate,
+      sentencingCourt: recommendation.nomisIndexOffence.allOptions[0].courtDescription,
       sentenceLength: {
-        partDays: 1,
-        partMonths: 2,
-        partYears: 3,
+        partDays: recommendation.nomisIndexOffence.allOptions[0].terms[0].days,
+        partMonths: recommendation.nomisIndexOffence.allOptions[0].terms[0].months,
+        partYears: recommendation.nomisIndexOffence.allOptions[0].terms[0].years,
       },
     })
 
     expect(updateRecommendation).toHaveBeenCalledWith({
-      recommendationId: '1',
+      recommendationId: recommendation.id,
       valuesToSave: {
         bookingMemento: {
-          offenderId: '767',
-          sentenceId: '445',
+          offenderId: bookingMemento.offenderId,
+          sentenceId: sentence.id,
           stage: 'SENTENCE_BOOKED',
         },
       },
-      token: 'token',
-      featureFlags: {
-        xyz: true,
-      },
+      token,
+      featureFlags,
     })
     expect(result).toEqual({
-      offenderId: '767',
-      sentenceId: '445',
+      offenderId: bookingMemento.offenderId,
+      sentenceId: sentence.id,
       stage: 'SENTENCE_BOOKED',
     })
   })

--- a/server/booking/createOrUpdateSentence.test.ts
+++ b/server/booking/createOrUpdateSentence.test.ts
@@ -111,6 +111,8 @@ describe('update sentence', () => {
         custodyType: 'Determinate',
         mappaLevel: 'Level 2 - local inter-agency management',
         ppudSentenceId: 'ADD_NEW',
+        legislationReleasedUnder: 'CJA 2023',
+        legislationSentencedUnder: 'CJA 2023',
       },
       nomisIndexOffence: {
         allOptions: [
@@ -153,6 +155,7 @@ describe('update sentence', () => {
       releaseDate: recommendation.nomisIndexOffence.allOptions[0].releaseDate,
       sentenceExpiryDate: recommendation.nomisIndexOffence.allOptions[0].sentenceEndDate,
       sentencingCourt: recommendation.nomisIndexOffence.allOptions[0].courtDescription,
+      sentencedUnder: recommendation.bookRecallToPpud.legislationSentencedUnder,
       sentenceLength: {
         partDays: recommendation.nomisIndexOffence.allOptions[0].terms[0].days,
         partMonths: recommendation.nomisIndexOffence.allOptions[0].terms[0].months,

--- a/server/booking/createOrUpdateSentence.ts
+++ b/server/booking/createOrUpdateSentence.ts
@@ -31,30 +31,23 @@ export default async function createOrUpdateSentence(
         }
       : null
 
+  const sentence = {
+    custodyType: recommendation.bookRecallToPpud?.custodyType,
+    mappaLevel: recommendation.bookRecallToPpud?.mappaLevel,
+    dateOfSentence: nomisOffence.sentenceDate,
+    licenceExpiryDate: nomisOffence.licenceExpiryDate,
+    releaseDate: nomisOffence.releaseDate,
+    sentenceLength,
+    sentenceExpiryDate: nomisOffence.sentenceEndDate,
+    sentencingCourt: nomisOffence.courtDescription,
+    sentencedUnder: recommendation.bookRecallToPpud?.legislationSentencedUnder,
+  }
   if (recommendation.bookRecallToPpud.ppudSentenceId === 'ADD_NEW') {
-    const createSentenceResponse = await ppudCreateSentence(token, memento.offenderId, {
-      custodyType: recommendation.bookRecallToPpud?.custodyType,
-      mappaLevel: recommendation.bookRecallToPpud?.mappaLevel,
-      dateOfSentence: nomisOffence.sentenceDate,
-      licenceExpiryDate: nomisOffence.licenceExpiryDate,
-      releaseDate: nomisOffence.releaseDate,
-      sentenceLength,
-      sentenceExpiryDate: nomisOffence.sentenceEndDate,
-      sentencingCourt: nomisOffence.courtDescription,
-    })
+    const createSentenceResponse = await ppudCreateSentence(token, memento.offenderId, sentence)
 
     memento.sentenceId = createSentenceResponse.sentence.id
   } else {
-    await ppudUpdateSentence(token, memento.offenderId, memento.sentenceId, {
-      custodyType: recommendation.bookRecallToPpud?.custodyType,
-      mappaLevel: recommendation.bookRecallToPpud?.mappaLevel,
-      dateOfSentence: nomisOffence.sentenceDate,
-      licenceExpiryDate: nomisOffence.licenceExpiryDate,
-      releaseDate: nomisOffence.releaseDate,
-      sentenceLength,
-      sentenceExpiryDate: nomisOffence.sentenceEndDate,
-      sentencingCourt: nomisOffence.courtDescription,
-    })
+    await ppudUpdateSentence(token, memento.offenderId, memento.sentenceId, sentence)
   }
 
   memento.stage = StageEnum.SENTENCE_BOOKED

--- a/server/booking/updateRelease.test.ts
+++ b/server/booking/updateRelease.test.ts
@@ -52,6 +52,7 @@ describe('update release', () => {
         policeForce: 'NCIS Los Angeles',
         probationArea: 'london',
         legislationReleasedUnder: 'CJA 2023',
+        legislationSentencedUnder: 'CJA 2023',
       },
       nomisIndexOffence: {
         allOptions: [

--- a/server/controllers/recommendation/editLegislationReleasedUnderController.test.ts
+++ b/server/controllers/recommendation/editLegislationReleasedUnderController.test.ts
@@ -35,28 +35,34 @@ describe('get', () => {
 
 describe('post', () => {
   it('post with valid data', async () => {
-    ;(getRecommendation as jest.Mock).mockResolvedValue({
+    const recommendation = {
       ...recommendationApiResponse,
       bookRecallToPpud: {
         policeForce: 'Kent',
       },
-    })
+    }
+    ;(getRecommendation as jest.Mock).mockResolvedValue(recommendation)
     ;(updateRecommendation as jest.Mock).mockResolvedValue(recommendationApiResponse)
 
     const basePath = `/recommendations/1/`
+    const legislationReleasedUnder = 'blue'
     const req = mockReq({
-      params: { recommendationId: '1' },
+      params: { recommendationId: recommendation.id.toString() },
       body: {
-        legislationReleasedUnder: 'blue',
+        legislationReleasedUnder,
       },
     })
 
+    const token = 'token1'
+
+    const featureFlags = { xyz: true }
+
     const res = mockRes({
-      token: 'token1',
+      token,
       locals: {
-        user: { token: 'token1' },
+        user: { token },
         urlInfo: { basePath },
-        flags: { xyz: true },
+        flags: featureFlags,
       },
     })
     const next = mockNext()
@@ -64,17 +70,15 @@ describe('post', () => {
     await editLegislationReleasedUnderController.post(req, res, next)
 
     expect(updateRecommendation).toHaveBeenCalledWith({
-      recommendationId: '1',
+      recommendationId: req.params.recommendationId,
       valuesToSave: {
         bookRecallToPpud: {
-          policeForce: 'Kent',
-          legislationReleasedUnder: 'blue',
+          policeForce: recommendation.bookRecallToPpud.policeForce,
+          legislationReleasedUnder,
         },
       },
-      token: 'token1',
-      featureFlags: {
-        xyz: true,
-      },
+      token,
+      featureFlags,
     })
 
     expect(res.redirect).toHaveBeenCalledWith(303, `/recommendations/1/check-booking-details`)

--- a/server/controllers/recommendation/editLegislationReleasedUnderController.test.ts
+++ b/server/controllers/recommendation/editLegislationReleasedUnderController.test.ts
@@ -75,6 +75,7 @@ describe('post', () => {
         bookRecallToPpud: {
           policeForce: recommendation.bookRecallToPpud.policeForce,
           legislationReleasedUnder,
+          legislationSentencedUnder: legislationReleasedUnder,
         },
       },
       token,

--- a/server/controllers/recommendation/editLegislationReleasedUnderController.ts
+++ b/server/controllers/recommendation/editLegislationReleasedUnderController.ts
@@ -67,6 +67,7 @@ async function post(req: Request, res: Response, _: NextFunction) {
       bookRecallToPpud: {
         ...recommendation.bookRecallToPpud,
         legislationReleasedUnder,
+        legislationSentencedUnder: legislationReleasedUnder,
       },
     },
     token,


### PR DESCRIPTION
The existing 'Released Under' field for PPUD Offender Releases is now re-used
also for PPUD Offender Sentences' 'Sentenced Under' field. This is reflected
both in its storage as a separate, new legislationSentencedUnder field in the
bookRecallToPpud structure as well as in the requests for creating and updating
PPUD sentences, as the legislation under which an offender was sentenced should
be the same as the one under which they were released.