### PR TITLE
MRD-2526 Fixing info endpoint (move to standard port)

### DIFF
--- a/scripts/start-services-for-e2e-tests-local.sh
+++ b/scripts/start-services-for-e2e-tests-local.sh
@@ -88,6 +88,6 @@ function wait_for {
 }
 
 wait_for "http://localhost:9090/auth/health/ping" "${AUTH_NAME}"
-wait_for "http://localhost:8081/health/readiness" "${API_NAME}"
+wait_for "http://localhost:8080/health/readiness" "${API_NAME}"
 
 printf "\n\nAll services are ready.\n\n"

--- a/scripts/start-services-for-e2e-tests.sh
+++ b/scripts/start-services-for-e2e-tests.sh
@@ -79,6 +79,6 @@ function wait_for {
 
 wait_for "http://localhost:9090/auth/health/ping" "${AUTH_NAME}"
 wait_for "http://localhost:3000/ping" "${UI_NAME}"
-wait_for "http://localhost:8081/health/readiness" "${API_NAME}"
+wait_for "http://localhost:8080/health/readiness" "${API_NAME}"
 
 printf "\n\nAll services are ready.\n\n"


### PR DESCRIPTION
Reverting management endpoints (health/info/prometheus) back to standard HTTP ports.
These were overridden to use 8081 on 03/05/22 by Darren Oakley for MRD-11