### PR TITLE
MRD-2611 Update autocomplete placeholder text

### DIFF
--- a/server/views/pages/recommendations/editReleasingPrison.njk
+++ b/server/views/pages/recommendations/editReleasingPrison.njk
@@ -34,7 +34,7 @@
                     errorMessage: errorMessage(errors.releasingPrison),
                     list: releasingPrisons,
                     value: recommendation.bookRecallToPpud.releasingPrison,
-                    placeholder: 'Select a prison',
+                    placeholder: 'Search for a prison',
                     nonce: cspNonce
                     })
                 }}

--- a/server/views/pages/recommendations/matchIndexOffence.njk
+++ b/server/views/pages/recommendations/matchIndexOffence.njk
@@ -41,7 +41,7 @@
                     errorMessage: errorMessage(errors.indexOffence),
                     list: indexOffences,
                     value: recommendation.bookRecallToPpud.indexOffence,
-                    placeholder: 'Select an offence',
+                    placeholder: 'Search for an offence',
                     nonce: cspNonce
                 })
                 }}


### PR DESCRIPTION
The placeholder text in the two autocomplete fields has been changed from
"Select X" to "Search for X", as the latter has a stronger implication or
suggestion of the field allowing the user to input text to search for the
option they want to select, rather than just having to scroll down to find the
appropriate option. The words "Type" and "Write" were also considered, but
discarded due to not being applicable in all cases (e.g. when certain
accessibility input devices are being used by the user).