### PR TITLE
MRD-2682 police contact details reset if

### DIFF
--- a/server/controllers/recommendation/custodyStatusController.test.ts
+++ b/server/controllers/recommendation/custodyStatusController.test.ts
@@ -135,8 +135,6 @@ describe('post', () => {
             { value: 'NO', text: 'No' },
           ],
         },
-        hasArrestIssues: null,
-        localPoliceContact: null,
       },
       featureFlags: {},
     })

--- a/server/controllers/recommendations/custodyStatus/formValidator.test.ts
+++ b/server/controllers/recommendations/custodyStatus/formValidator.test.ts
@@ -8,7 +8,7 @@ describe('validateCustodyStatus', () => {
     path: `/recommendations/${recommendationId}/custody-status`,
   }
 
-  it('returns valuesToSave and no errors if set to "Yes, police custody", and resets arrest issues / local police contact', async () => {
+  it('returns valuesToSave and no errors if set to "Yes, police custody"', async () => {
     const requestBody = {
       custodyStatus: 'YES_POLICE',
       custodyStatusDetailsYesPolice: 'West Ham Lane Police Station\n18 West Ham Lane\nStratford\nE15 4SG',
@@ -26,8 +26,6 @@ describe('validateCustodyStatus', () => {
         selected: 'YES_POLICE',
         details: 'West Ham Lane Police Station\n18 West Ham Lane\nStratford\nE15 4SG',
       },
-      hasArrestIssues: null,
-      localPoliceContact: null,
     })
     expect(nextPagePath).toEqual('/recommendations/34/task-list')
   })
@@ -46,7 +44,7 @@ describe('validateCustodyStatus', () => {
     )
   })
 
-  it('returns valuesToSave and no errors if Yes, prison selected, and resets details / arrest issues / local police contact', async () => {
+  it('returns valuesToSave and no errors if "Yes, prison" selected', async () => {
     const requestBody = {
       custodyStatus: 'YES_PRISON',
       crn: 'X34534',
@@ -63,8 +61,32 @@ describe('validateCustodyStatus', () => {
         selected: 'YES_PRISON',
         details: null,
       },
+    })
+    expect(valuesToSave).not.toContain({
       hasArrestIssues: null,
       localPoliceContact: null,
+    })
+    expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/task-list`)
+  })
+
+  it('returns valuesToSave, null details, and no errors if "No" selected', async () => {
+    const requestBody = {
+      custodyStatus: 'NO',
+      custodyStatusDetailsYesPolice: 'something from a previous entry',
+      crn: 'X34534',
+    }
+    const { errors, valuesToSave, nextPagePath } = await validateCustodyStatus({ requestBody, urlInfo })
+    expect(errors).toBeUndefined()
+    expect(valuesToSave).toEqual({
+      custodyStatus: {
+        allOptions: [
+          { value: 'YES_PRISON', text: 'Yes, prison custody' },
+          { value: 'YES_POLICE', text: 'Yes, police custody' },
+          { value: 'NO', text: 'No' },
+        ],
+        selected: 'NO',
+        details: null,
+      },
     })
     expect(nextPagePath).toEqual(`/recommendations/${recommendationId}/task-list`)
   })

--- a/server/controllers/recommendations/custodyStatus/formValidator.ts
+++ b/server/controllers/recommendations/custodyStatus/formValidator.ts
@@ -1,8 +1,6 @@
 import { makeErrorObject } from '../../../utils/errors'
 import { formOptions, isValueValid } from '../formOptions/formOptions'
 import { strings } from '../../../textStrings/en'
-import { isInCustody } from '../helpers/isInCustody'
-import { CustodyStatus } from '../../../@types/make-recall-decision-api'
 import { nextPageLinkUrl } from '../helpers/urls'
 import { isEmptyStringOrWhitespace, stripHtmlTags } from '../../../utils/utils'
 import { FormValidatorArgs, FormValidatorReturn } from '../../../@types/pagesForms'
@@ -43,20 +41,12 @@ export const validateCustodyStatus = async ({ requestBody, urlInfo }: FormValida
       },
     }
   }
-  const inCustody = isInCustody(custodyStatus as CustodyStatus.selected)
-  const resets = inCustody
-    ? {
-        hasArrestIssues: null,
-        localPoliceContact: null,
-      }
-    : {}
   const valuesToSave = {
     custodyStatus: {
       selected: custodyStatus,
       details: custodyStatus === 'YES_POLICE' ? stripHtmlTags(custodyStatusDetailsYesPolice as string) : null,
       allOptions: formOptions.custodyStatus,
     },
-    ...resets,
   }
   const nextPagePath = nextPageLinkUrl({ nextPageId: 'task-list', urlInfo })
   return {


### PR DESCRIPTION
The Police Contact Details are reset/nulled if the Custody Status is changed from “Yes, police custody” to either of the other two options.

Original Aug '22 logic: MRD-559: DEV: If PoP in custody, don't show arrest issues / police contact pages
Updated Feb '24 logic: MRD-2391: [Approved] Stop selecting 'in custody' hiding police contact info from task list

According to the second card, the contact details should not be reset/nulled.