### PR TITLE
MRD-2634 Config tidy up for caching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
 
   redis:
@@ -70,5 +69,4 @@ services:
 
 networks:
   hmpps:
-    external: true
     name: hmpps


### PR DESCRIPTION
Removing deprecated version. Removing unnecessary external network flag.