### PR TITLE
MRD-2744 Remove pre-prod e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,25 +508,11 @@ workflows:
           context:
             - hmpps-common-vars
           <<: *slack-fail-post-step
-      - e2e_environment_test:
-          name: e2e_test_preprod
-          environment: preprod
-          e2e-tags: "@smoke"
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - deploy_preprod
-          context:
-            - hmpps-common-vars
-          <<: *slack-fail-post-step
 
       - request-prod-approval:
           type: approval
           requires:
             - deploy_preprod
-            - e2e_test_preprod
       - hmpps/deploy_env:
           name: deploy_prod
           env: prod


### PR DESCRIPTION
The pre-prod e2e test run needs to be removed, as the data
originates in prod and shouldn't be used for anything other
than its original purpose (GDPR).

Additionally, MFA has just been added to pre-prod, which
would prevent the automated tests from going through anyway.