### PR TITLE
Update fix: paging for search results - by crn vs name

### DIFF
--- a/server/controllers/personSearch/personSearchResults.test.ts
+++ b/server/controllers/personSearch/personSearchResults.test.ts
@@ -88,7 +88,7 @@ describe('personSearchResults', () => {
     })
 
     await personSearchResults(req, res)
-    expect(searchPersons).toHaveBeenCalledWith('token', 0, 20, 'A123', undefined, undefined)
+    expect(searchPersons).toHaveBeenCalledWith('token', 1, 20, 'A123', undefined, undefined)
     expect(res.render).toHaveBeenCalledWith('pages/paginatedPersonSearchResults')
     expect(res.locals.page).toEqual(TEMPLATE)
 

--- a/server/controllers/personSearch/personSearchResults.ts
+++ b/server/controllers/personSearch/personSearchResults.ts
@@ -24,7 +24,7 @@ export const personSearchResults = async (req: Request, res: Response) => {
   }
   res.locals.crn = searchValue
   res.locals.hasPpcsRole = user.hasPpcsRole
-  res.locals.page = await searchPersons(user.token, Number(page) - 1, 20, searchValue, undefined, undefined)
+  res.locals.page = await searchPersons(user.token, Number(page), 20, searchValue, undefined, undefined)
   res.render('pages/paginatedPersonSearchResults')
   appInsightsEvent(EVENTS.PERSON_SEARCH_RESULTS, user.username, { crn: searchValue, region: user.region }, flags)
   await auditService.personSearch({

--- a/server/controllers/personSearch/personSearchResultsByName.test.ts
+++ b/server/controllers/personSearch/personSearchResultsByName.test.ts
@@ -38,7 +38,7 @@ describe('personSearchResultsByName', () => {
     })
 
     await personSearchResultsByName(req, res)
-    expect(searchPersons).toHaveBeenCalledWith('token', 0, 20, undefined, 'Harry', 'Bloggs')
+    expect(searchPersons).toHaveBeenCalledWith('token', 1, 20, undefined, 'Harry', 'Bloggs')
     expect(res.render).toHaveBeenCalledWith('pages/paginatedPersonSearchResults')
     expect(res.locals.page).toEqual(TEMPLATE)
 

--- a/server/controllers/personSearch/personSearchResultsByName.ts
+++ b/server/controllers/personSearch/personSearchResultsByName.ts
@@ -51,7 +51,7 @@ export const personSearchResultsByName = async (req: Request, res: Response) => 
   res.locals.lastName = lastName
   res.locals.hasPpcsRole = user.hasPpcsRole
 
-  res.locals.page = await searchPersons(user.token, Number(page) - 1, 20, undefined, firstName, lastName)
+  res.locals.page = await searchPersons(user.token, Number(page), 20, undefined, firstName, lastName)
   res.render('pages/paginatedPersonSearchResults')
   appInsightsEvent(EVENTS.PERSON_SEARCH_RESULTS, user.username, { lastName, firstName, region: user.region }, flags)
   await auditService.personSearch({

--- a/server/views/pages/paginatedPersonSearchResults.njk
+++ b/server/views/pages/paginatedPersonSearchResults.njk
@@ -83,7 +83,7 @@
     </table>
     {{ paginate({
         href: '/search-results-by-name?firstName=' + firstName + '&lastName='  + lastName,
-        index: page.paging.page + 1,
+        index: page.paging.page,
         total: page.paging.totalNumberOfPages
         }) }}
     {% endif %}


### PR DESCRIPTION
To reflect the changes in https://github.com/ministryofjustice/make-recall-decision-api/pull/1179

As the split in search endpoints has lead to different assumptions as the the index of the first page (by crn: 1, by name: 0) the managing of this has been moved into the API as an implementation details and now the UI and API will always communicate on the understanding that the first page has index 1.