### PR TITLE
Add non mandatory (discretionary) panel to recall type for FTR48

### DIFF
--- a/data/recommendations/recallTypeGenerator.ts
+++ b/data/recommendations/recallTypeGenerator.ts
@@ -1,0 +1,34 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { RecallType } from '../../server/@types/make-recall-decision-api/models/RecallType'
+import { RecallTypeSelectedValue } from '../../server/@types/make-recall-decision-api/models/RecallTypeSelectedValue'
+import { AnyNoneOrOption, DataGenerator } from '../@generators/dataGenerators'
+
+export type RecallTypeOptions = {
+  selected: {
+    value?: RecallTypeSelectedValue.value
+    details?: string
+  }
+}
+
+export const recallTypeGenerator: DataGenerator<RecallType, AnyNoneOrOption<RecallTypeOptions>> = {
+  generate: (options?: AnyNoneOrOption<RecallTypeOptions>) => {
+    if (options === 'any') {
+      return {
+        selected: {
+          value: faker.helpers.enumValue(RecallTypeSelectedValue.value),
+          details: faker.lorem.sentence(),
+        },
+        allOptions: [],
+      }
+    }
+    if (!options || options === 'none') {
+      return undefined
+    }
+    return {
+      selected: {
+        value: options.selected.value,
+        details: options.selected.details,
+      },
+    }
+  },
+}

--- a/data/recommendations/recommendationGenerator.ts
+++ b/data/recommendations/recommendationGenerator.ts
@@ -3,15 +3,15 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import { SelectedWithDetailsGenerator, SelectedWithDetailsOptions } from '../common/selectedWithDetailsGenerator'
 import { RoshEnum } from '../../server/@types/make-recall-decision-api/models/RoshData'
 import { BookRecallToPpudGenerator, BookRecallToPpudOptions } from './bookRecallToPpudGenerator'
-import { DataGenerator, NoneOrOption } from '../@generators/dataGenerators'
+import { AnyNoneOrOption, DataGenerator, NoneOrOption } from '../@generators/dataGenerators'
 import { CustodyStatus } from '../../server/@types/make-recall-decision-api/models/CustodyStatus'
 import { IndeterminateSentenceType } from '../../server/@types/make-recall-decision-api/models/IndeterminateSentenceType'
-import { RecallTypeSelectedValue } from '../../server/@types/make-recall-decision-api/models/RecallTypeSelectedValue'
 import { RecommendationResponse } from '../../server/@types/make-recall-decision-api/models/RecommendationResponse'
 import { VictimsInContactScheme } from '../../server/@types/make-recall-decision-api/models/VictimsInContactScheme'
 import { ConvictionDetailGenerator, ConvictionDetailOptions } from './convictionDetailGenerator'
 import { NomisIndexGenerator, NomisIndexOffenceOptions } from './nomisIndexOffenceGenerator'
 import { PpudOffenderGenerator, PpudOffenderOptions } from './ppudOffenderGenerator'
+import { recallTypeGenerator, RecallTypeOptions } from './recallTypeGenerator'
 
 /*
 / This is a WIP that returns only either undefined or basic random info for children based on a boolean.
@@ -41,7 +41,7 @@ export type RecommendationOptions = {
   offenceAnalysis?: boolean
   previousReleases?: boolean
   previousRecalls?: boolean
-  recallType?: boolean
+  recallType?: AnyNoneOrOption<RecallTypeOptions>
   decisionDateTime?: boolean
   responseToProbation?: boolean
   vulnerabilities?: boolean
@@ -210,16 +210,7 @@ export const RecommendationResponseGenerator: DataGenerator<RecommendationRespon
             previousRecallDates: [],
           }
         : undefined,
-    recallType:
-      options?.recallType ?? true
-        ? {
-            selected: {
-              value: RecallTypeSelectedValue.value.STANDARD,
-              details: faker.lorem.sentence(),
-            },
-            allOptions: [],
-          }
-        : undefined,
+    recallType: recallTypeGenerator.generate(options?.recallType ?? 'none'),
     decisionDateTime: options?.decisionDateTime ?? true ? faker.date.past().toISOString() : undefined,
     responseToProbation: options?.responseToProbation ?? true ? faker.lorem.sentence() : undefined,
     vulnerabilities:

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -1,0 +1,32 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+
+export type CriteriaDefinition<T extends Record<string, unknown>, P> = {
+  key: keyof T
+  generate: SupportedDefaultType | (() => P)
+}
+
+type SupportedDefaultType = 'boolean' | 'number' | 'string'
+
+export function randomiseCriteria<T extends Record<string, unknown>>(
+  definitions: Array<CriteriaDefinition<T, unknown>>,
+  criteria: (t: T) => boolean
+): T {
+  const resultMap: Map<keyof T, unknown> = new Map()
+  definitions.map(d => resultMap.set(d.key, resolveData(d.generate)))
+  const result = Object.fromEntries(resultMap) as T
+
+  return !criteria(result) ? randomiseCriteria(definitions, criteria) : result
+}
+
+function resolveData<P>(generate: SupportedDefaultType | (() => P)) {
+  switch (generate) {
+    case 'boolean':
+      return faker.datatype.boolean()
+    case 'number':
+      return faker.number.int()
+    case 'string':
+      return faker.string.alpha()
+    default:
+      return generate()
+  }
+}

--- a/integration_tests/integration/recommendationFormValidation.spec.ts
+++ b/integration_tests/integration/recommendationFormValidation.spec.ts
@@ -154,7 +154,7 @@ context('Make a recommendation - form validation', () => {
     cy.clickButton('Continue')
     cy.assertErrorMessage({
       fieldName: 'recallType',
-      errorText: 'Select a recommendation',
+      errorText: "Select if you're recommending a fixed term recall, standard recall, or no recall",
     })
   })
 

--- a/integration_tests/integration/recommendations/partA/recallType.spec.ts
+++ b/integration_tests/integration/recommendations/partA/recallType.spec.ts
@@ -1,0 +1,249 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { testForErrorPageTitle, testForErrorSummary } from '../../../componentTests/errors.tests'
+import { RecommendationResponseGenerator } from '../../../../data/recommendations/recommendationGenerator'
+
+context('Recal Type Page', () => {
+  const testPageUrl = `/recommendations/123456789/recall-type`
+
+  const defaultRecommendation = RecommendationResponseGenerator.generate({
+    recallType: 'none',
+  })
+
+  beforeEach(() => {
+    cy.task('getRecommendation', { statusCode: 200, response: defaultRecommendation })
+    cy.task('getStatuses', { statusCode: 200, response: [] })
+    cy.signIn()
+  })
+
+  describe('Page Data', () => {
+    it('Standard page load', () => {
+      cy.visit(testPageUrl)
+
+      // Page Heading
+      cy.pageHeading().should('equal', 'What do you recommend?')
+
+      // Recall type Radio inputs
+      cy.get('.govuk-form-group').should('have.length', 3).eq(0).as('recallTypeFormGroup')
+
+      cy.get('@recallTypeFormGroup').get('fieldset').should('exist').as('recallTypeFieldset')
+
+      cy.get('@recallTypeFieldset').get('legend').should('exist').should('contain.text', 'Select your recommendation')
+
+      cy.get('@recallTypeFieldset').get('.govuk-radios').should('exist').as('radioGroup')
+      cy.get('@radioGroup').get('div.govuk-radios__item').should('exist').should('have.length', 3).as('radios')
+
+      const testRecallTypeRadioButton = (
+        radioElement: () => Cypress.Chainable<JQuery<Element>>,
+        expectedId: string,
+        expectedLabel: string,
+        conditional?: { idSuffix: string }
+      ) => {
+        radioElement()
+          .find('input')
+          .should('exist')
+          .should('have.id', expectedId)
+          .should('have.attr', 'name', 'recallType')
+        radioElement()
+          .find('label')
+          .should('exist')
+          .should('have.attr', 'for', expectedId)
+          .should('contain.text', expectedLabel)
+
+        if (conditional) {
+          cy.get('@radioGroup')
+            .find(`.govuk-radios__conditional#conditional-${expectedId}`)
+            .should('exist')
+            .as('conditional')
+
+          cy.get('@conditional').find('.govuk-form-group').should('exist').as('conditionalGroup')
+
+          cy.get('@conditionalGroup')
+            .find('label')
+            .should('exist')
+            .should('have.attr', 'for', `recallTypeDetails${conditional.idSuffix}`)
+            .should('contain.text', 'Why do you recommend this recall type?')
+          cy.get('@conditionalGroup')
+            .find('textarea')
+            .should('exist')
+            .should('have.id', `recallTypeDetails${conditional.idSuffix}`)
+            .should('have.value', '')
+        }
+      }
+
+      testRecallTypeRadioButton(() => cy.get('@radios').eq(0), 'recallType', 'Standard recall', {
+        idSuffix: 'Standard',
+      })
+      testRecallTypeRadioButton(() => cy.get('@radios').eq(1), 'recallType-2', 'Fixed term recall', {
+        idSuffix: 'FixedTerm',
+      })
+      testRecallTypeRadioButton(
+        () => cy.get('@radios').eq(2),
+        'recallType-3',
+        'No recall - send a decision not to recall letter'
+      )
+
+      // Continue button
+      cy.get('button').should('have.class', 'govuk-button').should('contain.text', 'Continue')
+    })
+
+    describe('Given the FTR48 Feature is not enabled', () => {
+      beforeEach(() => {
+        cy.setCookie('flagFtr48Updates', '0')
+      })
+
+      it('The original FTR Conditions panel is displayed', () => {
+        cy.visit(testPageUrl)
+
+        cy.get('.govuk-notification-banner')
+          .should('exist')
+          .find('h2')
+          .should('exist')
+          .should('contain.text', 'Criminal Justice Act 2003 (Suitability for Fixed Term Recall) Order 2024')
+      })
+    })
+
+    describe('Given the FTR48 Feature is enabled', () => {
+      beforeEach(() => {
+        cy.setCookie('flagFtr48Updates', '1')
+      })
+
+      describe('And the Person on Probation does not meet any of the exception criteria', () => {
+        const recommendationWithoutExceptionCriteria = RecommendationResponseGenerator.generate({
+          isSentence48MonthsOrOver: false,
+          isUnder18: false,
+          isMappaCategory4: false,
+          isMappaLevel2Or3: false,
+          isRecalledOnNewChargedOffence: false,
+          isServingFTSentenceForTerroristOffence: false,
+          hasBeenChargedWithTerroristOrStateThreatOffence: false,
+        })
+        const expectedName = recommendationWithoutExceptionCriteria.personOnProbation.name
+
+        it('The the mandatory suitability panel is displayed', () => {
+          cy.task('getRecommendation', { statusCode: 200, response: recommendationWithoutExceptionCriteria })
+          cy.task('getStatuses', { statusCode: 200, response: [] })
+
+          cy.visit(testPageUrl)
+
+          cy.get('.moj-ticket-panel').should('exist').as('panel')
+
+          cy.get('@panel')
+            .find('h2')
+            .should('exist')
+            .should('contain.text', `${expectedName} must be given a fixed term recall, if recalled`)
+
+          cy.get('@panel').find('.govuk-details').should('exist').as('details')
+
+          cy.get('@details')
+            .find('summary')
+            .should('exist')
+            .should('contain.text', 'Understanding mandatory fixed term recalls')
+
+          cy.get('@details').find('.govuk-details__text').should('exist').as('detailsText')
+
+          cy.get('@detailsText')
+            .should(
+              'contain.text',
+              'Sentences under 48 months must be a given fixed term recall unless the person being recalled is:'
+            )
+            .should('contain.text', 'This applies to people aged 18 and over.')
+          cy.get('@detailsText')
+            .find('li')
+            .should('exist')
+            .should('have.length', 5)
+            .should('contain.text', 'being managed at MAPPA level 2 or 3, or in category 4, at the point of recall')
+            .should('contain.text', 'on an extended determinate sentence')
+            .should('contain.text', 'being recalled for a new charged offence')
+            .should(
+              'contain.text',
+              'serving a fixed term sentence for an offence within section 247A (2) of the Criminal Justice Act 2003 (terrorist prisoners) [The link opens in new tab]'
+            )
+            .should('contain.text', 'serving a sentence for a terrorist or state threat offence')
+            .find('a')
+            .should('exist')
+            .should('have.attr', 'href', 'https://www.legislation.gov.uk/ukpga/2003/44/section/247A')
+        })
+      })
+
+      describe('And the Person on Probation meets any of the exception criteria', () => {
+        const randomiseCriteria = (criteria: {
+          isSentence48MonthsOrOver?: boolean
+          isUnder18?: boolean
+          isMappaCategory4?: boolean
+          isMappaLevel2Or3?: boolean
+          isRecalledOnNewChargedOffence?: boolean
+          isServingFTSentenceForTerroristOffence?: boolean
+          hasBeenChargedWithTerroristOrStateThreatOffence?: boolean
+        }) => {
+          if (Object.keys(criteria).every(k => criteria[k] ?? false)) {
+            return randomiseCriteria({
+              isSentence48MonthsOrOver: faker.datatype.boolean(),
+              isUnder18: faker.datatype.boolean(),
+              isMappaCategory4: faker.datatype.boolean(),
+              isMappaLevel2Or3: faker.datatype.boolean(),
+              isRecalledOnNewChargedOffence: faker.datatype.boolean(),
+              isServingFTSentenceForTerroristOffence: faker.datatype.boolean(),
+              hasBeenChargedWithTerroristOrStateThreatOffence: faker.datatype.boolean(),
+            })
+          }
+          return criteria
+        }
+        const randomCriteria = randomiseCriteria({})
+        const recommendationWithExceptionCriteria = RecommendationResponseGenerator.generate({
+          isSentence48MonthsOrOver: randomCriteria.isSentence48MonthsOrOver,
+          isUnder18: randomCriteria.isUnder18,
+          isMappaCategory4: randomCriteria.isMappaCategory4,
+          isMappaLevel2Or3: randomCriteria.isMappaLevel2Or3,
+          isRecalledOnNewChargedOffence: randomCriteria.isRecalledOnNewChargedOffence,
+          isServingFTSentenceForTerroristOffence: randomCriteria.isServingFTSentenceForTerroristOffence,
+          hasBeenChargedWithTerroristOrStateThreatOffence:
+            randomCriteria.hasBeenChargedWithTerroristOrStateThreatOffence,
+        })
+        const expectedName = recommendationWithExceptionCriteria.personOnProbation.name
+
+        describe(`Randomised Criteria: 48+:${randomCriteria.isSentence48MonthsOrOver} | 18+:${randomCriteria.isUnder18} | M4:${randomCriteria.isMappaCategory4} | M2/3:${randomCriteria.isMappaLevel2Or3} | New:${randomCriteria.isRecalledOnNewChargedOffence} | STerr:${randomCriteria.isServingFTSentenceForTerroristOffence} | CTerr:${randomCriteria.hasBeenChargedWithTerroristOrStateThreatOffence}`, () => {
+          it('The the discretionary suitability panel is displayed', () => {
+            cy.task('getRecommendation', { statusCode: 200, response: recommendationWithExceptionCriteria })
+            cy.task('getStatuses', { statusCode: 200, response: [] })
+
+            cy.visit(testPageUrl)
+
+            cy.get('.moj-ticket-panel').should('exist').as('panel')
+
+            cy.get('@panel')
+              .find('h2')
+              .should('exist')
+              .should('contain.text', `${expectedName} can have either a fixed term or standard recall`)
+
+            cy.get('@panel')
+              .find('p')
+              .should('exist')
+              .should('have.class', 'govuk-body')
+              .should(
+                'have.text',
+                'Based on the information, if you decide to recommend a recall it can be either a fixed term or standard recall.'
+              )
+          })
+        })
+      })
+    })
+
+    describe('Error message display', () => {
+      describe('When no Recall Type is selected', () => {
+        it('Then the expected error message is displayed', () => {
+          cy.visit(testPageUrl)
+
+          cy.get('button.govuk-button').click()
+
+          testForErrorPageTitle()
+          testForErrorSummary([
+            {
+              href: 'recallType',
+              message: "Select if you're recommending a fixed term recall, standard recall, or no recall",
+            },
+          ])
+        })
+      })
+    })
+  })
+})

--- a/integration_tests/integration/recommendations/partA/recallType.spec.ts
+++ b/integration_tests/integration/recommendations/partA/recallType.spec.ts
@@ -1,8 +1,8 @@
-import { fakerEN_GB as faker } from '@faker-js/faker'
 import { testForErrorPageTitle, testForErrorSummary } from '../../../componentTests/errors.tests'
 import { RecommendationResponseGenerator } from '../../../../data/recommendations/recommendationGenerator'
+import { randomiseCriteria } from '../../../../data/utils'
 
-context('Recal Type Page', () => {
+context('Recall Type Page', () => {
   const testPageUrl = `/recommendations/123456789/recall-type`
 
   const defaultRecommendation = RecommendationResponseGenerator.generate({
@@ -119,7 +119,7 @@ context('Recal Type Page', () => {
         })
         const expectedName = recommendationWithoutExceptionCriteria.personOnProbation.name
 
-        it('The the mandatory suitability panel is displayed', () => {
+        it('Then the mandatory suitability panel is displayed', () => {
           cy.task('getRecommendation', { statusCode: 200, response: recommendationWithoutExceptionCriteria })
           cy.task('getStatuses', { statusCode: 200, response: [] })
 
@@ -166,29 +166,27 @@ context('Recal Type Page', () => {
       })
 
       describe('And the Person on Probation meets any of the exception criteria', () => {
-        const randomiseCriteria = (criteria: {
-          isSentence48MonthsOrOver?: boolean
-          isUnder18?: boolean
-          isMappaCategory4?: boolean
-          isMappaLevel2Or3?: boolean
-          isRecalledOnNewChargedOffence?: boolean
-          isServingFTSentenceForTerroristOffence?: boolean
-          hasBeenChargedWithTerroristOrStateThreatOffence?: boolean
-        }) => {
-          if (Object.keys(criteria).every(k => criteria[k] ?? false)) {
-            return randomiseCriteria({
-              isSentence48MonthsOrOver: faker.datatype.boolean(),
-              isUnder18: faker.datatype.boolean(),
-              isMappaCategory4: faker.datatype.boolean(),
-              isMappaLevel2Or3: faker.datatype.boolean(),
-              isRecalledOnNewChargedOffence: faker.datatype.boolean(),
-              isServingFTSentenceForTerroristOffence: faker.datatype.boolean(),
-              hasBeenChargedWithTerroristOrStateThreatOffence: faker.datatype.boolean(),
-            })
-          }
-          return criteria
-        }
-        const randomCriteria = randomiseCriteria({})
+        const randomCriteria = randomiseCriteria<{
+          isSentence48MonthsOrOver: boolean
+          isUnder18: boolean
+          isMappaCategory4: boolean
+          isMappaLevel2Or3: boolean
+          isRecalledOnNewChargedOffence: boolean
+          isServingFTSentenceForTerroristOffence: boolean
+          hasBeenChargedWithTerroristOrStateThreatOffence: boolean
+        }>(
+          [
+            { key: 'isSentence48MonthsOrOver', generate: 'boolean' },
+            { key: 'isUnder18', generate: 'boolean' },
+            { key: 'isMappaCategory4', generate: 'boolean' },
+            { key: 'isMappaLevel2Or3', generate: 'boolean' },
+            { key: 'isRecalledOnNewChargedOffence', generate: 'boolean' },
+            { key: 'isServingFTSentenceForTerroristOffence', generate: 'boolean' },
+            { key: 'hasBeenChargedWithTerroristOrStateThreatOffence', generate: 'boolean' },
+          ],
+          criteria => !Object.keys(criteria).every(k => criteria[k] ?? false)
+        )
+
         const recommendationWithExceptionCriteria = RecommendationResponseGenerator.generate({
           isSentence48MonthsOrOver: randomCriteria.isSentence48MonthsOrOver,
           isUnder18: randomCriteria.isUnder18,
@@ -202,7 +200,7 @@ context('Recal Type Page', () => {
         const expectedName = recommendationWithExceptionCriteria.personOnProbation.name
 
         describe(`Randomised Criteria: 48+:${randomCriteria.isSentence48MonthsOrOver} | 18+:${randomCriteria.isUnder18} | M4:${randomCriteria.isMappaCategory4} | M2/3:${randomCriteria.isMappaLevel2Or3} | New:${randomCriteria.isRecalledOnNewChargedOffence} | STerr:${randomCriteria.isServingFTSentenceForTerroristOffence} | CTerr:${randomCriteria.hasBeenChargedWithTerroristOrStateThreatOffence}`, () => {
-          it('The the discretionary suitability panel is displayed', () => {
+          it('Then the discretionary suitability panel is displayed', () => {
             cy.task('getRecommendation', { statusCode: 200, response: recommendationWithExceptionCriteria })
             cy.task('getStatuses', { statusCode: 200, response: [] })
 

--- a/server/controllers/recommendations/recallType/formValidator.test.ts
+++ b/server/controllers/recommendations/recallType/formValidator.test.ts
@@ -329,7 +329,7 @@ describe('validateRecallType', () => {
         {
           href: '#recallType',
           name: 'recallType',
-          text: 'Select a recommendation',
+          text: "Select if you're recommending a fixed term recall, standard recall, or no recall",
           errorId: 'noRecallTypeSelected',
         },
       ])
@@ -346,7 +346,7 @@ describe('validateRecallType', () => {
         {
           href: '#recallType',
           name: 'recallType',
-          text: 'Select a recommendation',
+          text: "Select if you're recommending a fixed term recall, standard recall, or no recall",
           errorId: 'noRecallTypeSelected',
         },
       ])

--- a/server/helpers/ppudSentence/ppudSentenceHelper.test.ts
+++ b/server/helpers/ppudSentence/ppudSentenceHelper.test.ts
@@ -111,6 +111,12 @@ describe('getIndeterminateSentences', () => {
 
     expect(actualIndeterminateSentences).toEqual([])
   })
+
+  it('returns an empty list if given an undefined list', () => {
+    const actualIndeterminateSentences = getIndeterminateSentences(undefined)
+
+    expect(actualIndeterminateSentences).toEqual([])
+  })
 })
 
 describe('getSentenceType', () => {

--- a/server/testUtils/booleanUtils.ts
+++ b/server/testUtils/booleanUtils.ts
@@ -1,0 +1,15 @@
+export const generateBooleanCombinations = (n: number) => {
+  const p: Array<Array<boolean>> = []
+  const forBothValues = (b: boolean, c: number, r: Array<boolean>) => {
+    if (c > 0) {
+      r.push(b)
+      ;[true, false].forEach(v => forBothValues(v, c - 1, [...r]))
+    } else if (b) {
+      p.push(r)
+    }
+  }
+  ;[true, false].forEach(v => {
+    forBothValues(v, n, [])
+  })
+  return p
+}

--- a/server/testUtils/booleanUtils.ts
+++ b/server/testUtils/booleanUtils.ts
@@ -1,3 +1,23 @@
+/**
+ * Generates all possible combinations of boolean for a given number of booleans
+ * @param n The number of booleans to generate combinations
+ * @returns A array of boolean arrays representing every possible combination of boolean, each of length n
+ *
+ * @example
+ * generateBooleanCombinations(1)
+ * // returns [[true], [false]]
+ *
+ * @example
+ * generateBooleanCombinations(2)
+ * // returns [[true, true], [true, false], [false, true], [false, false]]
+ *
+ * @example
+ * generateBooleanCombinations(3)
+ * // returns [
+ * //   [true, true, true], [true, true, false], [true, false, true], [true, false, false],
+ * //   [false, true, true], [false, true, false], [false, false, true], [false, false, false]
+ * // ]
+ */
 export const generateBooleanCombinations = (n: number) => {
   const p: Array<Array<boolean>> = []
   const forBothValues = (b: boolean, c: number, r: Array<boolean>) => {

--- a/server/textStrings/en.ts
+++ b/server/textStrings/en.ts
@@ -27,7 +27,7 @@ export const strings: Record<string, Record<string, string>> = {
     saveChanges: 'An error occurred saving your changes',
     noIndexOffenceSelected: 'Select an index offence',
     noPpudSentenceSelected: 'Select an existing sentence or add a new one',
-    noRecallTypeSelected: 'Select a recommendation',
+    noRecallTypeSelected: "Select if you're recommending a fixed term recall, standard recall, or no recall",
     noRecallTypeExtendedSelected: 'Select whether you recommend a recall or not',
     noRecallTypeIndeterminateSelected: 'Select whether you recommend a recall or not',
     missingRecallTypeDetail: 'Explain why you recommend this recall type',

--- a/server/views/partials/recommendation/recallTypeFTR.njk
+++ b/server/views/partials/recommendation/recallTypeFTR.njk
@@ -1,63 +1,67 @@
 <h1 class="govuk-heading-l">{{ pageTitles[page.id] }}</h1>
 {% set notificationBannerHtml %}
-<p class="govuk-body ">
-    For sentences under 12 months, recalls must be fixed term unless either:
-    <ul>
-        <li>the person has been charged with a serious offence (murder or an offence listed in
-            <a target="_blank" rel="noopener noreferrer" href="https://www.legislation.gov.uk/ukpga/2020/17/schedule/18">Schedule 18
-                of the Sentencing Act 2020</a>)
-        </li>
-        <li>the MAPPA level is 2 or 3 at the point of recall</li>
-    </ul>
-    This applies to people aged 18 and over only.
-</p>
-<p>
-    You have said that:
-    <ul>
-        <li>{{ recommendation.personOnProbation.name }}
-            <strong>is</strong>
-            {% if recommendation.isUnder18 == false %}
-                <strong>not</strong>
-            {% endif %}
-            under 18</li>
-        <li>the sentence
-            <strong>is</strong>
-            {% if recommendation.isSentence12MonthsOrOver == false %}
-                <strong>not</strong>
-            {% endif %}
-            12 months or over</li>
-        <li>the MAPPA level
-            <strong>is</strong>
-            {% if recommendation.isMappaLevelAbove1 == false %}
-                <strong>not</strong>
-            {% endif %}
-            above 1</li>
-        <li>{{ recommendation.personOnProbation.name }}
-            <strong>has</strong>
-            {% if recommendation.hasBeenConvictedOfSeriousOffence == false %}
-                <strong>not</strong>
-            {% endif %}
-            been charged with a serious offence.</li>
-    </ul>
-    {% if recommendation.isUnder18 or recommendation.isSentence12MonthsOrOver or recommendation.isMappaLevelAbove1 or recommendation.hasBeenConvictedOfSeriousOffence %}
-        {% set warningText = ["If you decide to recall ", recommendation.personOnProbation.name, ", it does not have to be a fixed term recall. Explain why you have chosen the recall type."] | join %}
-    {% else %}
-        {% set warningText = ["If you decide to recall ", recommendation.personOnProbation.name, ", it should be an automatic fixed term recall."] | join %}
-    {% endif %}
-    {{ govukWarningText({
-        text: warningText,
-        iconFallbackText: "Warning"
-    }) }}
-</p>
+    <p class="govuk-body ">
+        For sentences under 12 months, recalls must be fixed term unless either:
+        <ul>
+            <li>the person has been charged with a serious offence (murder or an offence listed in
+                <a target="_blank" rel="noopener noreferrer" href="https://www.legislation.gov.uk/ukpga/2020/17/schedule/18">Schedule 18
+                    of the Sentencing Act 2020</a>)
+            </li>
+            <li>the MAPPA level is 2 or 3 at the point of recall</li>
+        </ul>
+        This applies to people aged 18 and over only.
+    </p>
+    <p>
+        You have said that:
+        <ul>
+            <li>{{ recommendation.personOnProbation.name }}
+                <strong>is</strong>
+                {% if recommendation.isUnder18 == false %}
+                    <strong>not</strong>
+                {% endif %}
+                under 18</li>
+            <li>the sentence
+                <strong>is</strong>
+                {% if recommendation.isSentence12MonthsOrOver == false %}
+                    <strong>not</strong>
+                {% endif %}
+                12 months or over</li>
+            <li>the MAPPA level
+                <strong>is</strong>
+                {% if recommendation.isMappaLevelAbove1 == false %}
+                    <strong>not</strong>
+                {% endif %}
+                above 1</li>
+            <li>{{ recommendation.personOnProbation.name }}
+                <strong>has</strong>
+                {% if recommendation.hasBeenConvictedOfSeriousOffence == false %}
+                    <strong>not</strong>
+                {% endif %}
+                been charged with a serious offence.</li>
+        </ul>
+        {% if recommendation.isUnder18 or recommendation.isSentence12MonthsOrOver or recommendation.isMappaLevelAbove1 or recommendation.hasBeenConvictedOfSeriousOffence %}
+            {% set warningText = ["If you decide to recall ", recommendation.personOnProbation.name, ", it does not have to be a fixed term recall. Explain why you have chosen the recall type."] | join %}
+        {% else %}
+            {% set warningText = ["If you decide to recall ", recommendation.personOnProbation.name, ", it should be an automatic fixed term recall."] | join %}
+        {% endif %}    
+        {{ govukWarningText({
+            text: warningText,
+            iconFallbackText: "Warning"
+        }) }}
+    </p>
 {% endset %}
 
 {% if ftr48Enabled %}
-{% include "../../partials/recommendation/recallTypeFTRConditionsPanel.njk" %}
+    {% if ftrMandatory %}
+        {% include "../../partials/recommendation/recallTypeFTRConditionsPanel.njk" %}
+    {% else %}
+        {% include "../../partials/recommendation/recallTypeFTRDiscretionaryConditionsPanel.njk" %}
+    {% endif %}
 {% else %}
-{{ govukNotificationBanner({
-    html: notificationBannerHtml,
-    titleText: "Criminal Justice Act 2003 (Suitability for Fixed Term Recall) Order 2024"
-}) }}
+    {{ govukNotificationBanner({
+        html: notificationBannerHtml,
+        titleText: "Criminal Justice Act 2003 (Suitability for Fixed Term Recall) Order 2024"
+    }) }}
 {% endif %}
 {{ govukRadios({
     idPrefix: "recallType",

--- a/server/views/partials/recommendation/recallTypeFTRDiscretionaryConditionsPanel.njk
+++ b/server/views/partials/recommendation/recallTypeFTRDiscretionaryConditionsPanel.njk
@@ -1,0 +1,13 @@
+{% set discretionaryPanelTextHtml %}
+    {% set panelHeadingText = [recommendation.personOnProbation.name, " can have either a fixed term or standard recall"] | join %}
+    {{ heading(panelHeadingText, 2, "m") }}
+
+    {{ bodyParagraph("Based on the information, if you decide to recommend a recall it can be either a fixed term or standard recall.") }}
+{% endset %}
+
+{{ mojTicketPanel({
+    items: [{
+        html: discretionaryPanelTextHtml,
+        classes: "moj-ticket-panel__content--blue"
+    }]
+}) }}


### PR DESCRIPTION
[MRD-2786 Change recommendation screen - suitability for FTR [Discretionary path] or Standard](https://dsdmoj.atlassian.net/browse/MRD-2786)

Add discretionary panel to the recall type controller if the FTR48 feature is enabled and any of the exclusion criteria (values from the suitability for recall type page) apply.
Else continue to display the mandatory panel.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/76381eb8-7e94-455e-bf28-39e3f3b11d73" />