### PR TITLE
Change literal opens in new tab note to GDS new tab link

### DIFF
--- a/integration_tests/integration/recommendations/partA/recallType.spec.ts
+++ b/integration_tests/integration/recommendations/partA/recallType.spec.ts
@@ -144,7 +144,7 @@ context('Recall Type Page', () => {
           cy.get('@detailsText')
             .should(
               'contain.text',
-              'Sentences under 48 months must be a given fixed term recall unless the person being recalled is:'
+              'Sentences under 48 months must be given a fixed term recall unless the person being recalled is:'
             )
             .should('contain.text', 'This applies to people aged 18 and over.')
           cy.get('@detailsText')
@@ -156,12 +156,15 @@ context('Recall Type Page', () => {
             .should('contain.text', 'being recalled for a new charged offence')
             .should(
               'contain.text',
-              'serving a fixed term sentence for an offence within section 247A (2) of the Criminal Justice Act 2003 (terrorist prisoners) [The link opens in new tab]'
+              'serving a fixed term sentence for an offence within section 247A (2) of the Criminal Justice Act 2003 (terrorist prisoners) (opens in new tab)'
             )
             .should('contain.text', 'serving a sentence for a terrorist or state threat offence')
             .find('a')
             .should('exist')
+            .should('have.class', 'govuk-link')
             .should('have.attr', 'href', 'https://www.legislation.gov.uk/ukpga/2003/44/section/247A')
+            .should('have.attr', 'rel', 'noreferrer noopener')
+            .should('have.attr', 'target', '_blank')
         })
       })
 

--- a/server/views/partials/recommendation/recallTypeFTRConditionsPanel.njk
+++ b/server/views/partials/recommendation/recallTypeFTRConditionsPanel.njk
@@ -5,12 +5,12 @@
     {{ govukDetails({
         summaryText: "Understanding mandatory fixed term recalls",
         html: "
-        <p>Sentences under 48 months must be a given fixed term recall unless the person being recalled is:
+        <p>Sentences under 48 months must be given a fixed term recall unless the person being recalled is:
         <ul>
             <li>being managed at MAPPA level 2 or 3, or in category 4, at the point of recall</li>
             <li>on an extended determinate sentence</li>
             <li>being recalled for a new charged offence</li>
-            <li>serving a fixed term sentence for an offence within <a href=https://www.legislation.gov.uk/ukpga/2003/44/section/247A>section 247A (2) of the Criminal Justice Act 2003 (terrorist prisoners)</a> [The link opens in new tab]</li>
+            <li>serving a fixed term sentence for an offence within <a class='govuk-link' rel='noreferrer noopener' target='_blank' href='https://www.legislation.gov.uk/ukpga/2003/44/section/247A'>section 247A (2) of the Criminal Justice Act 2003 (terrorist prisoners) (opens in new tab)</a></li>
             <li>serving a sentence for a terrorist or state threat offence</li>
         </ul>
         </p>


### PR DESCRIPTION
The `[opens in new tab]` part of the copy text was apparently a reference and not a literal piece of copy.

With our content designer not back until tomorrow I have
A) made this functionally open in a new tab
B) used the default mark up for a link that opens in a new tab

Both as [specified in GDS](https://design-system.service.gov.uk/styles/links/#opening-links-in-a-new-tab).

Once Steph is back we can tweak the context before release if required but this will account for the functionality.

Also correcting a minor typo: `must be a given` -> `must be given a`

<img width="820" height="723" alt="image" src="https://github.com/user-attachments/assets/ec5469cf-0c6e-4830-9b23-fc2da84535d9" />