### PR TITLE
FTR48 Fixups: Recall Type error message

### DIFF
--- a/integration_tests/integration/recommendationFormValidation.spec.ts
+++ b/integration_tests/integration/recommendationFormValidation.spec.ts
@@ -154,7 +154,7 @@ context('Make a recommendation - form validation', () => {
     cy.clickButton('Continue')
     cy.assertErrorMessage({
       fieldName: 'recallType',
-      errorText: "Select if you're recommending a fixed term recall, standard recall, or no recall",
+      errorText: "Select if you're recommending a fixed term recall, standard recall or no recall",
     })
   })
 

--- a/integration_tests/integration/recommendations/partA/recallType.spec.ts
+++ b/integration_tests/integration/recommendations/partA/recallType.spec.ts
@@ -227,22 +227,40 @@ context('Recall Type Page', () => {
           })
         })
       })
-    })
 
-    describe('Error message display', () => {
-      describe('When no Recall Type is selected', () => {
-        it('Then the expected error message is displayed', () => {
-          cy.visit(testPageUrl)
+      describe('Error message display', () => {
+        describe('When no Recall Type is selected', () => {
+          ;[true, false].forEach(ftrMandatory => {
+            describe(`FTR Mandatory: ${ftrMandatory}`, () => {
+              it('Then the expected error message is displayed', () => {
+                const recommendationForMandatoryValue = RecommendationResponseGenerator.generate({
+                  isSentence48MonthsOrOver: !ftrMandatory,
+                  isUnder18: !ftrMandatory,
+                  isMappaCategory4: !ftrMandatory,
+                  isMappaLevel2Or3: !ftrMandatory,
+                  isRecalledOnNewChargedOffence: !ftrMandatory,
+                  isServingFTSentenceForTerroristOffence: !ftrMandatory,
+                  hasBeenChargedWithTerroristOrStateThreatOffence: !ftrMandatory,
+                })
+                cy.task('getRecommendation', { statusCode: 200, response: recommendationForMandatoryValue })
+                cy.task('getStatuses', { statusCode: 200, response: [] })
 
-          cy.get('button.govuk-button').click()
+                cy.visit(testPageUrl)
 
-          testForErrorPageTitle()
-          testForErrorSummary([
-            {
-              href: 'recallType',
-              message: "Select if you're recommending a fixed term recall, standard recall, or no recall",
-            },
-          ])
+                cy.get('button.govuk-button').click()
+
+                testForErrorPageTitle()
+                testForErrorSummary([
+                  {
+                    href: 'recallType',
+                    message: ftrMandatory
+                      ? "Select if you're recommending a fixed term recall or no recall"
+                      : "Select if you're recommending a fixed term recall, standard recall or no recall",
+                  },
+                ])
+              })
+            })
+          })
         })
       })
     })

--- a/integration_tests/integration/recommendations/partA/recallType.spec.ts
+++ b/integration_tests/integration/recommendations/partA/recallType.spec.ts
@@ -70,11 +70,11 @@ context('Recall Type Page', () => {
         }
       }
 
-      testRecallTypeRadioButton(() => cy.get('@radios').eq(0), 'recallType', 'Standard recall', {
-        idSuffix: 'Standard',
-      })
-      testRecallTypeRadioButton(() => cy.get('@radios').eq(1), 'recallType-2', 'Fixed term recall', {
+      testRecallTypeRadioButton(() => cy.get('@radios').eq(0), 'recallType', 'Fixed term recall', {
         idSuffix: 'FixedTerm',
+      })
+      testRecallTypeRadioButton(() => cy.get('@radios').eq(1), 'recallType-2', 'Standard recall', {
+        idSuffix: 'Standard',
       })
       testRecallTypeRadioButton(
         () => cy.get('@radios').eq(2),

--- a/server/controllers/recommendations/recallType/formOptions.ts
+++ b/server/controllers/recommendations/recallType/formOptions.ts
@@ -1,5 +1,5 @@
 export const recallType = [
-  { value: 'STANDARD', text: 'Standard recall' },
   { value: 'FIXED_TERM', text: 'Fixed term recall' },
+  { value: 'STANDARD', text: 'Standard recall' },
   { value: 'NO_RECALL', text: 'No recall - send a decision not to recall letter' },
 ]

--- a/server/controllers/recommendations/recallType/formValidator.test.ts
+++ b/server/controllers/recommendations/recallType/formValidator.test.ts
@@ -318,38 +318,52 @@ describe('validateRecallType', () => {
       ])
     })
 
-    it('returns an error for the decision, if not set', async () => {
-      const requestBody = {
-        recallType: '',
-        crn: 'X34534',
-      }
-      const { errors, valuesToSave } = await validateRecallType({ requestBody, recommendationId, urlInfo })
-      expect(valuesToSave).toBeUndefined()
-      expect(errors).toEqual([
-        {
-          href: '#recallType',
-          name: 'recallType',
-          text: "Select if you're recommending a fixed term recall, standard recall, or no recall",
-          errorId: 'noRecallTypeSelected',
-        },
-      ])
+    describe('returns an error for the decision, if not set', () => {
+      ;[true, false].forEach(ftrMandatory => {
+        it(`FTR is Mandatory: ${ftrMandatory}`, async () => {
+          const requestBody = {
+            recallType: '',
+            crn: 'X34534',
+            ftrMandatory: ftrMandatory.toString(),
+          }
+          const { errors, valuesToSave } = await validateRecallType({ requestBody, recommendationId, urlInfo })
+          expect(valuesToSave).toBeUndefined()
+          expect(errors).toEqual([
+            {
+              href: '#recallType',
+              name: 'recallType',
+              text: ftrMandatory
+                ? "Select if you're recommending a fixed term recall or no recall"
+                : "Select if you're recommending a fixed term recall, standard recall or no recall",
+              errorId: ftrMandatory ? 'noRecallTypeSelectedMandatory' : 'noRecallTypeSelectedDiscretionary',
+            },
+          ])
+        })
+      })
     })
 
-    it('returns an error, if recallType is set to an invalid value', async () => {
-      const requestBody = {
-        recallType: 'VALUE',
-        crn: 'X34534',
-      }
-      const { errors, valuesToSave } = await validateRecallType({ requestBody, recommendationId, urlInfo })
-      expect(valuesToSave).toBeUndefined()
-      expect(errors).toEqual([
-        {
-          href: '#recallType',
-          name: 'recallType',
-          text: "Select if you're recommending a fixed term recall, standard recall, or no recall",
-          errorId: 'noRecallTypeSelected',
-        },
-      ])
+    describe('returns an error, if recallType is set to an invalid value', () => {
+      ;[true, false].forEach(ftrMandatory => {
+        it(`FTR is Mandatory: ${ftrMandatory}`, async () => {
+          const requestBody = {
+            recallType: 'VALUE',
+            crn: 'X34534',
+            ftrMandatory: ftrMandatory.toString(),
+          }
+          const { errors, valuesToSave } = await validateRecallType({ requestBody, recommendationId, urlInfo })
+          expect(valuesToSave).toBeUndefined()
+          expect(errors).toEqual([
+            {
+              href: '#recallType',
+              name: 'recallType',
+              text: ftrMandatory
+                ? "Select if you're recommending a fixed term recall or no recall"
+                : "Select if you're recommending a fixed term recall, standard recall or no recall",
+              errorId: ftrMandatory ? 'noRecallTypeSelectedMandatory' : 'noRecallTypeSelectedDiscretionary',
+            },
+          ])
+        })
+      })
     })
   })
 })

--- a/server/controllers/recommendations/recallType/formValidator.ts
+++ b/server/controllers/recommendations/recallType/formValidator.ts
@@ -6,7 +6,8 @@ import { EVENTS } from '../../../utils/constants'
 import { FormValidatorArgs, FormValidatorReturn } from '../../../@types/pagesForms'
 
 export const validateRecallType = async ({ requestBody, urlInfo }: FormValidatorArgs): FormValidatorReturn => {
-  const { recallType, recallTypeDetailsFixedTerm, recallTypeDetailsStandard, originalRecallType } = requestBody
+  const { recallType, recallTypeDetailsFixedTerm, recallTypeDetailsStandard, originalRecallType, ftrMandatory } =
+    requestBody
   const invalidRecallType = !isValueValid(recallType as string, 'recallType')
   const isFixedTerm = recallType === 'FIXED_TERM'
   const isStandard = recallType === 'STANDARD'
@@ -15,11 +16,12 @@ export const validateRecallType = async ({ requestBody, urlInfo }: FormValidator
   const missingDetailStandard = isStandard && !recallTypeDetailsStandard
   const isFromTaskList = urlInfo.fromPageId === 'task-list'
   const hasError = !recallType || invalidRecallType || missingDetailFixedTerm || missingDetailStandard
+  const ftrMandatoryResolved = ftrMandatory === 'true'
   if (hasError) {
     const errors = []
     let errorId
     if (!recallType || invalidRecallType) {
-      errorId = 'noRecallTypeSelected'
+      errorId = ftrMandatoryResolved ? 'noRecallTypeSelectedMandatory' : 'noRecallTypeSelectedDiscretionary'
       errors.push(
         makeErrorObject({
           id: 'recallType',

--- a/server/textStrings/en.ts
+++ b/server/textStrings/en.ts
@@ -27,7 +27,9 @@ export const strings: Record<string, Record<string, string>> = {
     saveChanges: 'An error occurred saving your changes',
     noIndexOffenceSelected: 'Select an index offence',
     noPpudSentenceSelected: 'Select an existing sentence or add a new one',
-    noRecallTypeSelected: "Select if you're recommending a fixed term recall, standard recall, or no recall",
+    noRecallTypeSelectedDiscretionary:
+      "Select if you're recommending a fixed term recall, standard recall or no recall",
+    noRecallTypeSelectedMandatory: "Select if you're recommending a fixed term recall or no recall",
     noRecallTypeExtendedSelected: 'Select whether you recommend a recall or not',
     noRecallTypeIndeterminateSelected: 'Select whether you recommend a recall or not',
     missingRecallTypeDetail: 'Explain why you recommend this recall type',

--- a/server/utils/lists.test.ts
+++ b/server/utils/lists.test.ts
@@ -130,17 +130,17 @@ describe('List utilities', () => {
       })
       expect(result).toEqual([
         {
-          checked: false,
-          text: 'Standard recall',
-          value: 'STANDARD',
-        },
-        {
           text: 'Fixed term recall',
           value: 'FIXED_TERM',
           checked: true,
           conditional: {
             html: '<div>test</div>',
           },
+        },
+        {
+          checked: false,
+          text: 'Standard recall',
+          value: 'STANDARD',
         },
         {
           checked: false,

--- a/server/views/pages/recommendations/recallType.njk
+++ b/server/views/pages/recommendations/recallType.njk
@@ -35,6 +35,7 @@
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
                 <input type="hidden" name="crn" value="{{ recommendation.crn }}"/>
                 <input type="hidden" name="originalRecallType" value="{{ inputDisplayValues.value }}"/>
+                <input type="hidden" name="ftrMandatory" value="{{ ftrMandatory }}"/>
                 {% include "../../partials/recommendation/recallTypeFTR.njk" %}
                 {{ formSubmitButton() }}
             </form>


### PR DESCRIPTION
Modulate noRecallType error messages into Mandatory and Discretionary variants

Discretionary recall error message referring to all three options: Standard, Fixed Term and no recall
<img width="861" height="953" alt="Discretionary Error Message" src="https://github.com/user-attachments/assets/6fdb16e1-42c2-4ae1-a7d4-bfeda358e173" />


Update Mandatory recall error message referring only to Fixed Term and No Recall
<img width="861" height="953" alt="Mandatory Error Message" src="https://github.com/user-attachments/assets/72f5cf98-0c4d-4598-b32f-79801b45a75f" />

Additionally, change the order of `Fixed Term` and `Standard` Recall options as UCD wishes Fixed Term to be the presumed default and offered as the lead option.
This matches the designs in [MRD-2775](https://dsdmoj.atlassian.net/browse/MRD-2775) but it was not apparent that the order of the inputs mattered until we noticed that the error message listed them in a different order so they were simply in the order they have always been.


[MRD-2775]: https://dsdmoj.atlassian.net/browse/MRD-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ