### PR TITLE
FTR48 Fixups: 

### DIFF
--- a/server/views/partials/recommendation/recallTypeFTR.njk
+++ b/server/views/partials/recommendation/recallTypeFTR.njk
@@ -55,6 +55,10 @@
     {% if ftrMandatory %}
         {% include "../../partials/recommendation/recallTypeFTRConditionsPanel.njk" %}
     {% else %}
+        {% set conditionalContent = {
+            STANDARD: standardDetailHtml,
+            FIXED_TERM: fixedTermDetailHtml
+        } %}
         {% include "../../partials/recommendation/recallTypeFTRDiscretionaryConditionsPanel.njk" %}
     {% endif %}
 {% else %}
@@ -62,6 +66,10 @@
         html: notificationBannerHtml,
         titleText: "Criminal Justice Act 2003 (Suitability for Fixed Term Recall) Order 2024"
     }) }}
+    {% set conditionalContent = {
+        STANDARD: standardDetailHtml,
+        FIXED_TERM: fixedTermDetailHtml
+    } %}
 {% endif %}
 {{ govukRadios({
     idPrefix: "recallType",
@@ -75,10 +83,7 @@
     items: radioCheckboxItems({
         items: availableRecallTypes,
         currentValues: inputDisplayValues.value,
-        conditionalContent: {
-            STANDARD: standardDetailHtml,
-            FIXED_TERM: fixedTermDetailHtml
-        }
+        conditionalContent: conditionalContent
     }),
     errorMessage: errorMessage(errors.recallType)
 }) }}


### PR DESCRIPTION
Only include Recall type rational when rendering for pre-FTR48 or when the decision is discretionary.

None FTR48 Version: maintained
<img width="1920" height="948" alt="image" src="https://github.com/user-attachments/assets/c4fa278e-b995-4fb7-b27a-166c2015678c" />

FTR48 Version - Discretionary: maintained
<img width="1920" height="948" alt="image" src="https://github.com/user-attachments/assets/33e412e3-87ed-4db5-959a-6709c0a53bd2" />

FTR48 Version - Mandatory: no longer present
<img width="969" height="948" alt="image" src="https://github.com/user-attachments/assets/6485370f-26e5-4aa5-b30a-a099edbf295c" />
