### PR TITLE
MRD-2833 Show suitability for STD in task list

### DIFF
--- a/server/views/partials/taskList/circumstances.njk
+++ b/server/views/partials/taskList/circumstances.njk
@@ -81,7 +81,7 @@ set suitabilityForFixedTermRecall = hasData(recommendation.isUnder18) or
                 <span id='task-list-status-fixedTermAdditionalLicenceConditions'>{{ taskStatus({ hasData: hasData(recommendation.fixedTermAdditionalLicenceConditions) }) }}</span>
             </li>
         {% endif %}
-        {% if recommendation.isIndeterminateSentence == false and recommendation.isExtendedSentence == false and recommendation.recallType.selected.value === 'FIXED_TERM' %}
+        {% if recommendation.isIndeterminateSentence == false and recommendation.isExtendedSentence == false %}
             <li class="moj-task-list__item">
                 <span class="moj-task-list__task-name">
                     <a aria-describedby='task-list-status-suitabilityForFixedTermRecall' href="{{ changeLinkUrl({ pageUrlSlug: 'suitability-for-fixed-term-recall', urlInfo: urlInfo, fromAnchor: 'heading-circumstances' }) }}">Suitability for fixed term recall</a>


### PR DESCRIPTION
The suitability page is relevant for all non-extended, non-indeterminate
sentences. The display criteria for the link to the page in the task list is
amended here.