### PR TITLE
MRD-2838: Correct Suitability task list text

### DIFF
--- a/integration_tests/integration/recommendationTaskList.spec.ts
+++ b/integration_tests/integration/recommendationTaskList.spec.ts
@@ -336,7 +336,7 @@ context('Recommendation - task list', () => {
     })
     cy.task('getStatuses', { statusCode: 200, response: [] })
     cy.visit(`${routeUrls.recommendations}/${recommendationId}/task-list`)
-    cy.getElement('Suitability for fixed term recall To do').should('exist')
+    cy.getElement('Suitability for standard or fixed term recall To do').should('exist')
   })
   it('task list - determinate, not extended, fixed term recall and FTR flag and suitability completed', () => {
     cy.task('getRecommendation', {
@@ -351,7 +351,7 @@ context('Recommendation - task list', () => {
     })
     cy.task('getStatuses', { statusCode: 200, response: [] })
     cy.visit(`${routeUrls.recommendations}/${recommendationId}/task-list`)
-    cy.getElement('Suitability for fixed term recall Completed').should('exist')
+    cy.getElement('Suitability for standard or fixed term recall Completed').should('exist')
   })
 
   describe('Routing', () => {

--- a/server/views/partials/taskList/circumstances.njk
+++ b/server/views/partials/taskList/circumstances.njk
@@ -84,7 +84,7 @@ set suitabilityForFixedTermRecall = hasData(recommendation.isUnder18) or
         {% if recommendation.isIndeterminateSentence == false and recommendation.isExtendedSentence == false %}
             <li class="moj-task-list__item">
                 <span class="moj-task-list__task-name">
-                    <a aria-describedby='task-list-status-suitabilityForFixedTermRecall' href="{{ changeLinkUrl({ pageUrlSlug: 'suitability-for-fixed-term-recall', urlInfo: urlInfo, fromAnchor: 'heading-circumstances' }) }}">Suitability for fixed term recall</a>
+                    <a aria-describedby='task-list-status-suitabilityForFixedTermRecall' href="{{ changeLinkUrl({ pageUrlSlug: 'suitability-for-fixed-term-recall', urlInfo: urlInfo, fromAnchor: 'heading-circumstances' }) }}">Suitability for standard or fixed term recall</a>
                 </span>
                 <span id='task-list-status-suitabilityForFixedTermRecall'>{{ taskStatus({ hasData: suitabilityForFixedTermRecall }) }}</span>
             </li>


### PR DESCRIPTION
[MRD-2838](https://dsdmoj.atlassian.net/browse/MRD-2838)

Requested change to the text for the _suitability for... ...recall_ task list item

Before: captured in dev
<img width="825" height="163" alt="image" src="https://github.com/user-attachments/assets/a6a77640-59dc-4a92-9632-8934c50b484f" />

Updated: capture against this branch
<img width="825" height="163" alt="image" src="https://github.com/user-attachments/assets/661b5056-ad0d-4325-bd31-b549bffeb76c" />


[MRD-2838]: https://dsdmoj.atlassian.net/browse/MRD-2838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ