### PR TITLE
MRD-2835: Suitability for Recall always navigates to Recall Type

### DIFF
--- a/server/controllers/recommendation/suitabilityForFixedTermRecallController.test.ts
+++ b/server/controllers/recommendation/suitabilityForFixedTermRecallController.test.ts
@@ -1,4 +1,4 @@
-import { faker } from '@faker-js/faker'
+import { fakerEN_GB as faker } from '@faker-js/faker'
 import { mockNext, mockReq, mockRes } from '../../middleware/testutils/mockRequestUtils'
 import { updateRecommendation } from '../../data/makeDecisionApiClient'
 import recommendationApiResponse from '../../../api/responses/get-recommendation.json'
@@ -532,5 +532,40 @@ describe('post', () => {
       })
       expect(res.redirect).toHaveBeenCalledWith(303, `some-url`)
     })
+  })
+
+  it('preserves fromPageId and fromAnchor when provided', async () => {
+    const expectedFromPageId = faker.word.noun()
+    const expectedFromAnchor = faker.word.adjective()
+    const req = mockReq({
+      params: { recommendationId: '123' },
+      body: {
+        isUnder18: 'YES',
+        isSentence48MonthsOrOver: 'YES',
+        isMappaCategory4: 'YES',
+        isMappaLevel2Or3: 'YES',
+        isRecalledOnNewChargedOffence: 'YES',
+        isServingFTSentenceForTerroristOffence: 'YES',
+        hasBeenChargedWithTerroristOrStateThreatOffence: 'YES',
+      },
+    })
+
+    const res = mockRes({
+      token: 'token1',
+      locals: {
+        recommendation: { personOnProbation: { name: faker.person.fullName() } },
+        urlInfo: { basePath, fromPageId: expectedFromPageId, fromAnchor: expectedFromAnchor },
+        statuses: [],
+        flags: { flagFtr48Updates: true },
+      },
+    })
+    const next = mockNext()
+
+    await suitabilityForFixedTermRecallController.post(req, res, next)
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      303,
+      `/recommendations/123/recall-type?fromPageId=${expectedFromPageId}&fromAnchor=${expectedFromAnchor}`
+    )
   })
 })

--- a/server/controllers/recommendation/suitabilityForFixedTermRecallController.ts
+++ b/server/controllers/recommendation/suitabilityForFixedTermRecallController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
 import { updateRecommendation } from '../../data/makeDecisionApiClient'
-import { nextPageLinkUrl } from '../recommendations/helpers/urls'
+import { nextPagePreservingFromPageAndAnchor } from '../recommendations/helpers/urls'
 import { booleanToYesNo } from '../../utils/utils'
 import { isValueValid } from '../recommendations/formOptions/formOptions'
 import { makeErrorObject } from '../../utils/errors'
@@ -174,7 +174,7 @@ async function post(req: Request, res: Response, _: NextFunction) {
     featureFlags: flags,
   })
 
-  res.redirect(303, nextPageLinkUrl({ nextPageId: 'recall-type', urlInfo }))
+  res.redirect(303, nextPagePreservingFromPageAndAnchor({ pageUrlSlug: 'recall-type', urlInfo }))
 }
 
 export default { get, post }

--- a/server/controllers/recommendations/helpers/urls.test.ts
+++ b/server/controllers/recommendations/helpers/urls.test.ts
@@ -1,4 +1,5 @@
-import { changeLinkUrl, checkForRedirectPath, nextPageLinkUrl } from './urls'
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { changeLinkUrl, checkForRedirectPath, nextPageLinkUrl, nextPagePreservingFromPageAndAnchor } from './urls'
 import { RecallTypeSelectedValue } from '../../../@types/make-recall-decision-api/models/RecallTypeSelectedValue'
 import { RecommendationResponse } from '../../../@types/make-recall-decision-api/models/RecommendationResponse'
 
@@ -50,6 +51,57 @@ describe('changeLinkUrl', () => {
     }
     const url = changeLinkUrl({ pageUrlSlug: 'recall-type', urlInfo, fromAnchor: 'heading-recommendation' })
     expect(url).toEqual('/recommendations/123/recall-type?fromPageId=task-list&fromAnchor=heading-recommendation')
+  })
+})
+
+describe('nextPagePreservingFromPageAndAnchor', () => {
+  const nextPageTestSlug = 'test-next-slug'
+  const testPath = 'path/is/required'
+  it('returns the base url and page slug when no UrlInfo details present', () => {
+    const expectedBasePath = faker.internet.url()
+    const urlInfo = {
+      path: testPath,
+      basePath: expectedBasePath,
+    }
+    const result = nextPagePreservingFromPageAndAnchor({ pageUrlSlug: nextPageTestSlug, urlInfo })
+    expect(result).toEqual(`${expectedBasePath}${nextPageTestSlug}`)
+  })
+  it('returns the base url and page slug with fromPageId when provided', () => {
+    const expectedBasePath = faker.internet.url()
+    const expectedFromPageId = faker.word.noun()
+    const urlInfo = {
+      path: testPath,
+      basePath: expectedBasePath,
+      fromPageId: expectedFromPageId,
+    }
+    const result = nextPagePreservingFromPageAndAnchor({ pageUrlSlug: nextPageTestSlug, urlInfo })
+    expect(result).toEqual(`${expectedBasePath}${nextPageTestSlug}?fromPageId=${expectedFromPageId}`)
+  })
+  it('returns the base url and page slug with fromAnchor when provided', () => {
+    const expectedBasePath = faker.internet.url()
+    const expectedFromAchorId = faker.word.adjective()
+    const urlInfo = {
+      path: testPath,
+      basePath: expectedBasePath,
+      fromAnchor: expectedFromAchorId,
+    }
+    const result = nextPagePreservingFromPageAndAnchor({ pageUrlSlug: nextPageTestSlug, urlInfo })
+    expect(result).toEqual(`${expectedBasePath}${nextPageTestSlug}?fromAnchor=${expectedFromAchorId}`)
+  })
+  it('returns the base url and page slug with both fromPageId and fromAnchor when provided', () => {
+    const expectedBasePath = faker.internet.url()
+    const expectedFromPageId = faker.word.noun()
+    const expectedFromAchorId = faker.word.adjective()
+    const urlInfo = {
+      path: testPath,
+      basePath: expectedBasePath,
+      fromPageId: expectedFromPageId,
+      fromAnchor: expectedFromAchorId,
+    }
+    const result = nextPagePreservingFromPageAndAnchor({ pageUrlSlug: nextPageTestSlug, urlInfo })
+    expect(result).toEqual(
+      `${expectedBasePath}${nextPageTestSlug}?fromPageId=${expectedFromPageId}&fromAnchor=${expectedFromAchorId}`
+    )
   })
 })
 

--- a/server/controllers/recommendations/helpers/urls.ts
+++ b/server/controllers/recommendations/helpers/urls.ts
@@ -44,6 +44,18 @@ export const changeLinkUrl = ({
   return `${basePath}${pageUrlSlug}${queryParam}`
 }
 
+export const nextPagePreservingFromPageAndAnchor = ({
+  pageUrlSlug,
+  urlInfo,
+}: {
+  pageUrlSlug: string
+  urlInfo: UrlInfo
+}) => {
+  const { basePath, fromPageId, fromAnchor } = urlInfo
+  const queryParam = `${fromPageId ? `?fromPageId=${fromPageId}` : ''}${fromAnchor ? `${fromPageId ? '&' : '?'}fromAnchor=${fromAnchor}` : ''}`
+  return `${basePath}${pageUrlSlug}${queryParam}`
+}
+
 export const checkForRedirectPath = ({
   requestedPageId,
   recommendation,


### PR DESCRIPTION
SuitabilityForRecall page always navigates to RecallType page but preserves from params (fromPageId and fromAnchor) so RecallType can return if these are present in its stead.

This currently matter for the Task List page where a user entering the Suitability for Recall page needs to stop via the Recall Type page in case any of the conditions have changed.