### PR TITLE
Changes MRD API to route to local service endpoint to avoid ingress n…

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,7 @@ generic-service:
     INGRESS_URL: "https://consider-a-recall.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
-    MAKE_RECALL_DECISION_API_URL: "https://make-recall-decision-api.hmpps.service.justice.gov.uk"
+    MAKE_RECALL_DECISION_API_URL: "http://make-recall-decision-api.make-recall-decision-prod.svc.cluster.local"
     MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     MAKE_RECALL_DECISIONS_AND_DELIUS_API_URL: "https://make-recall-decisions-and-delius.hmpps.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "PROD"


### PR DESCRIPTION
…ginx 499s

Uses http as https ssl is terminated at the ingress.