### PR TITLE
MRD-3173 fix the UI cves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5266,9 +5266,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12390,9 +12390,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
More CVEs 

```
=== npm audit security report ===                                            
+---------+----------------+-----------------------------+----------+---------------------------------------------------+
| ID      | Module         | Paths                       | Severity | URL                                               |
+---------+----------------+-----------------------------+----------+---------------------------------------------------+
| 1115806 | lodash         | node_modules/lodash         | high     | https://github.com/advisories/GHSA-r5fr-rjxr-66jc |
| 1115997 | @xmldom/xmldom | node_modules/@xmldom/xmldom | high     | https://github.com/advisories/GHSA-wh4c-j3r5-mjhp |
| 1115810 | lodash         | node_modules/lodash         | moderate | https://github.com/advisories/GHSA-f23m-r3pf-42rh |
+---------+----------------+-----------------------------+----------+---------------------------------------------------+
```

Fixed automatically using `npm audit fix` 