### PR TITLE
MRD-3175 add in an env var to specifically tell it to use fallback he…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV GIT_REF=${GIT_REF}
 ENV GIT_BRANCH=${GIT_BRANCH}
 
 # Stage: build assets
-FROM base as build
+FROM base AS build
 
 ARG BUILD_NUMBER
 ARG GIT_REF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - MAKE_RECALL_DECISIONS_AND_DELIUS_API_URL=http://fake-delius-integration-api:8080
       - TOKEN_VERIFICATION_API_URL=http://hmpps-auth:9090/verification
       - FEATURE_FLAGFTR56ENABLED=${FEATURE_FLAGFTR56ENABLED:-2026-03-30T23:00Z}
+      - USE_LOCAL_HEADER_FALLBACKS=${USE_LOCAL_HEADER_FALLBACKS:-false}
       # These will need to match new creds in the seed auth service auth
       - API_CLIENT_ID=make-recall-decision-ui
       - API_CLIENT_SECRET=clientsecret

--- a/server/app.ts
+++ b/server/app.ts
@@ -60,7 +60,8 @@ export default function createApp(userService: UserService): express.Application
     pdsComponents.getPageComponents({
       pdsUrl: config.apis.probationApi.url,
       logger,
-      useFallbacksByDefault: ['local', 'test'].includes(process.env.ENVIRONMENT),
+      useFallbacksByDefault:
+        ['local', 'test'].includes(process.env.ENVIRONMENT) || process.env.USE_LOCAL_HEADER_FALLBACKS === 'true',
     }),
   )
 


### PR DESCRIPTION
It appears that when the E2E repo is running its "integration_tests" stage, it's using a script (`e2erepo/scripts/start-services-integration.sh`) which is calling the `docker-compose.yml` from *this* repo and building the app for testing using the Dockerfile. 

As the Dockerfile's used with Kubernetes, it *always* sets the environment to `production` so when that `integration_test` step is run it thinks it's in the production environment and starts trying to make calls to get the PDS header/footer via the API. This call has a timeout it has to wait for, but also retries so it's adding a *lot* of overhead to the calls and this appears to be why the E2E tests are taking so long.

This PR adds in a flag for specifically enabling the fallback headers which we can then call via the E2E tests and that should remove this overhead, without removing the actual headers when it's on an environment.

