### PR TITLE
Fix sentenceToCommitIndeterminate.spec.ts

### DIFF
--- a/integration_tests/integration/recommendations/ppcs/indeterminateSentences/sentenceToCommitIndeterminate.spec.ts
+++ b/integration_tests/integration/recommendations/ppcs/indeterminateSentences/sentenceToCommitIndeterminate.spec.ts
@@ -33,7 +33,7 @@ context('Indeterminate Sentence - Sentence to Commit Page', () => {
               return {
                 custodyType: indeterminateCustodyType,
                 sentenceLength: {
-                  partYears: faker.number.int({ min: 0, max: 10 }),
+                  partYears: faker.number.int({ min: 1, max: 10 }),
                 },
               }
             }),


### PR DESCRIPTION
The sentenceLength needs to be greater than zero. Otherwise, if set to zero,
the formatPpudSentenceLength function called later on returns nothing, but the
testSummaryList one requires a non-null value.