### PR TITLE
fix ui cves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
         "@types/uuid": "^10.0.0",
         "audit-ci": "^7.0.0",
         "axe-core": "4.10.0",
-        "concurrently": "^9.0.0",
         "cypress": "^15.16.0",
         "cypress-axe": "1.7.0",
         "cypress-multi-reporters": "^2.0.5",
@@ -7162,31 +7161,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/connect-flash": {
@@ -16436,6 +16410,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -17219,19 +17194,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shelljs": {

--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "@types/uuid": "^10.0.0",
     "audit-ci": "^7.0.0",
     "axe-core": "4.10.0",
-    "concurrently": "^9.0.0",
     "cypress": "^15.16.0",
     "cypress-axe": "1.7.0",
     "cypress-multi-reporters": "^2.0.5",


### PR DESCRIPTION
There was a vulnerability with a transitive dependency called `shell-quote` which was only used by a direct dependency called `concurrently` 

However, `concurrently` was only used in the old build process which has been superseded by ESBuild, so we just removed concurrently and we're back to secure :)